### PR TITLE
Add path-level parameters handling

### DIFF
--- a/src/openapi.spec.loader.ts
+++ b/src/openapi.spec.loader.ts
@@ -48,8 +48,15 @@ export class OpenApiSpecLoader {
           const bp = bpa.replace(/\/$/, '');
           for (const [path, methods] of Object.entries(apiDoc.paths)) {
             for (const [method, schema] of Object.entries(methods)) {
+              if (method === 'parameters') {
+                continue;
+              }
+              const schemaParameters = new Set();
+              (schema.parameters || []).forEach(parameter => schemaParameters.add(parameter));
+              ((methods as any).parameters || []).forEach(parameter => schemaParameters.add(parameter));
+              schema.parameters = Array.from(schemaParameters);
               const pathParams = new Set();
-              for (const param of schema.parameters || []) {
+              for (const param of schema.parameters) {
                 if (param.in === 'path') {
                   pathParams.add(param.name);
                 }

--- a/test/path.level.parameters.spec.ts
+++ b/test/path.level.parameters.spec.ts
@@ -1,0 +1,80 @@
+import * as path from 'path';
+import * as express from 'express';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { createApp } from './common/app';
+
+const packageJson = require('../package.json');
+
+describe(packageJson.name, () => {
+  let app = null;
+  let basePath = null;
+
+  before(async () => {
+    // Set up the express app
+    const apiSpec = path.join(
+      'test',
+      'resources',
+      'path.level.parameters.yaml',
+    );
+    app = await createApp({ apiSpec }, 3005);
+    basePath = app.basePath;
+
+    // Define new coercion routes
+    app.use(
+      `${basePath}`,
+      express
+        .Router()
+        .get(`/path_level_parameters`, (_req, res) => res.send())
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should return 400 if pathLevel query parameter is not provided', async () =>
+    request(app)
+      .get(`${basePath}/path_level_parameters?operationLevel=123`)
+      .send()
+      .expect(400)
+      .then(r => {
+        expect(r.body.errors).to.be.an('array')
+        expect(r.body.errors).to.have.length(1);
+        const message = r.body.errors[0].message;
+        expect(message).to.equal('should have required property \'pathLevel\'');
+      }));
+
+  it('should return 400 if operationLevel query parameter is not provided', async () =>
+    request(app)
+      .get(`${basePath}/path_level_parameters?pathLevel=123`)
+      .send()
+      .expect(400)
+      .then(r => {
+        expect(r.body.errors).to.be.an('array')
+        expect(r.body.errors).to.have.length(1);
+        const message = r.body.errors[0].message;
+        expect(message).to.equal('should have required property \'operationLevel\'');
+      }));
+
+  it('should return 400 if neither operationLevel, nor pathLevel query parameters are provided', async () =>
+    request(app)
+      .get(`${basePath}/path_level_parameters`)
+      .send()
+      .expect(400)
+      .then(r => {
+        expect(r.body.errors).to.be.an('array')
+        expect(r.body.errors).to.have.length(2);
+        const messages = r.body.errors.map(err => err.message);
+        expect(messages).to.have.members([
+          'should have required property \'pathLevel\'',
+          'should have required property \'operationLevel\''
+        ]);
+      }));
+
+  it('should return 200 if both pathLevel and operationLevel query parameter are provided', async () =>
+    request(app)
+      .get(`${basePath}/path_level_parameters?operationLevel=123&pathLevel=123`)
+      .send()
+      .expect(200));
+});

--- a/test/resources/path.level.parameters.yaml
+++ b/test/resources/path.level.parameters.yaml
@@ -1,0 +1,36 @@
+openapi: '3.0.2'
+info:
+  version: 1.0.0
+  title: Path Level Parameters
+  description: Path Level Parameters Test
+
+servers:
+  - url: /v1/
+
+paths:
+  /path_level_parameters:
+    parameters:
+      - $ref: '#components/parameters/pathLevelParameter'
+    get:
+      parameters:
+        - $ref: '#components/parameters/operationLevelParameter'
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad Request
+
+components:
+  parameters:
+    pathLevelParameter:
+      name: pathLevel
+      in: query
+      required: true
+      schema:
+        type: string
+    operationLevelParameter:
+      name: operationLevel
+      in: query
+      required: true
+      schema:
+        type: string


### PR DESCRIPTION
As of today `express-openapi-validator` considers path-level parameters `path.parameters` (ref.: [https://swagger.io/docs/specification/describing-parameters/#common-for-path](https://swagger.io/docs/specification/describing-parameters/#common-for-path)) as method. So, those parameters are not used for request validation.

This PR adds path-level parameters to method-level parameters and ignores `path.parameters` as being a method.