### PR TITLE
Add support for using $ref in requestBody

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -156,7 +156,12 @@ export class RequestValidator {
 
   private buildMiddleware(path, pathSchema, contentType) {
     const parameters = this.parametersToSchema(path, pathSchema.parameters);
-    const requestBody = pathSchema.requestBody;
+    let requestBody = pathSchema.requestBody;
+
+    if (requestBody && requestBody.hasOwnProperty('$ref')) {
+      const id = requestBody.$ref.replace(/^.+\//i, '');
+      requestBody = this._apiDocs.components.requestBodies[id];
+    }
 
     let body = this.requestBodyToSchema(path, contentType, requestBody);
     let requiredAdds = requestBody && requestBody.required ? ['body'] : [];

--- a/test/request.bodies.ref.spec.ts
+++ b/test/request.bodies.ref.spec.ts
@@ -1,0 +1,55 @@
+import * as path from 'path';
+import * as express from 'express';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { createApp } from './common/app';
+
+const packageJson = require('../package.json');
+
+describe(packageJson.name, () => {
+  let app = null;
+  let basePath = null;
+
+  before(async () => {
+    // Set up the express app
+    const apiSpec = path.join(
+      'test',
+      'resources',
+      'request.bodies.ref.yaml',
+    );
+    app = await createApp({ apiSpec }, 3005);
+    basePath = app.basePath;
+
+    // Define new coercion routes
+    app.use(
+      `${basePath}`,
+      express
+        .Router()
+        .post(`/request_bodies_ref`, (req, res) => res.json(req.body))
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should return 400 if testProperty body property is not provided', async () =>
+    request(app)
+      .post(`${basePath}/request_bodies_ref`)
+      .send({})
+      .expect(400)
+      .then(r => {
+        expect(r.body.errors).to.be.an('array')
+        expect(r.body.errors).to.have.length(1);
+        const message = r.body.errors[0].message;
+        expect(message).to.equal('should have required property \'testProperty\'');
+      }));
+
+  it('should return 200 if testProperty body property is provided', async () =>
+    request(app)
+      .post(`${basePath}/request_bodies_ref`)
+      .send({
+        testProperty: 'abc'
+      })
+      .expect(200));
+});

--- a/test/resources/request.bodies.ref.yaml
+++ b/test/resources/request.bodies.ref.yaml
@@ -1,0 +1,33 @@
+openapi: '3.0.2'
+info:
+  version: 1.0.0
+  title: requestBodies $ref
+  description: requestBodies $ref Test
+
+servers:
+  - url: /v1/
+
+paths:
+  /request_bodies_ref:
+    post:
+      requestBody:
+        $ref: '#components/requestBodies/TestBody'
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Bad Request
+
+components:
+  requestBodies:
+    TestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              testProperty:
+                type: string
+            required:
+              - testProperty


### PR DESCRIPTION
This PR adds support for referencing ```requestBody``` from ```components/requestBodies```