### PR TITLE
Document how validation only applies underneath the server's base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,27 @@ app.use((err, req, res, next) => {
 });
 ```
 
+## The Base URL
+
+The validator will only validate requests — and (optionally) responses — that are under
+the server's [base URL](https://spec.openapis.org/oas/v3.0.0.html#serverVariableObject).
+
+This is useful for those times when the API and frontend are being served by the same
+application. ([More detail about the base URL](https://swagger.io/docs/specification/api-host-and-base-path/).)
+
+```yaml
+servers:
+  - url: https://api.example.com/v1
+``` 
+
+The validation applies to all paths defined under this base URL. Routes in your app
+that are _not_ under the base URL—such as pages—will not be validated.
+
+| URL                                  | Validated?                  |
+| :----------------------------------- | :-------------------------- |
+| `https://api.example.com/v1/users`   | :white_check_mark:          |
+| `https://api.example.com/index.html` | no; not under the base URL  |
+
 ## [Example Express API Server](https://github.com/cdimascio/express-openapi-validator-example) (clone it)
 
 A fully working example lives [here](https://github.com/cdimascio/express-openapi-validator-example)


### PR DESCRIPTION
closes #52

<img width="831" alt="Screen Shot 2019-09-22 at 11 28 12" src="https://user-images.githubusercontent.com/1855109/65385898-288adf00-dd2c-11e9-9a65-d516ddef3f24.png">

The README is getting a bit long now and this is just bodged in there: it's not especially discoverable. This section doesn't say what to do if you're co-locating your frontend and API but under the same base URL: i.e. what do you do when you're _not_ using something like `/api` or `/v1` in your base URL? I'd like to expand on that but now we're veering into documentation as _guide_ rather than documentation as _reference_ so I've chosen to keep it terse.

I've submitted this PR anyway 'cos the README can be structured and hyperlinked to form better reference documentation in a subsequent PR, yeah?