### PR TITLE
Errors for unknown format #48 and #56

### DIFF
--- a/src/middlewares/ajv/index.ts
+++ b/src/middlewares/ajv/index.ts
@@ -13,10 +13,11 @@ export function createResponseAjv(openApiSpec, options: any = {}) {
 function createAjv(openApiSpec, options: any = {}, request: boolean = true) {
   const ajv = new Ajv({
     ...options,
-    formats: { ...formats, ...options.formats },
     schemaId: 'auto',
     allErrors: true,
     meta: draftSchema,
+    formats: { ...formats, ...options.formats },
+    unknownFormats: options.unknownFormats,
   });
   ajv.removeKeyword('propertyNames');
   ajv.removeKeyword('contains');

--- a/test/request.bodies.ref.spec.ts
+++ b/test/request.bodies.ref.spec.ts
@@ -13,7 +13,7 @@ describe(packageJson.name, () => {
   before(async () => {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'request.bodies.ref.yaml');
-    app = await createApp({ apiSpec }, 3005);
+    app = await createApp({ apiSpec, unknownFormats: ['phone-number'] }, 3005);
     basePath = app.basePath;
 
     // Define new coercion routes

--- a/test/resources/request.bodies.ref.yaml
+++ b/test/resources/request.bodies.ref.yaml
@@ -30,5 +30,7 @@ components:
             properties:
               testProperty:
                 type: string
+                example: +15017122661
+                format: phone-number
             required:
               - testProperty


### PR DESCRIPTION
adds support for unknown formats via the option `unknownFormats`
specifying `unknownFormats: true` will enable any formats. However, if a valid format is specified incorrectly e.g. a typo. It is ignore, thus no validation help is provided

To get validation help while ignoring formats, one can also specify `unknownFormats: ['phone-number', 'uuid', 'etc']`. This method requires a bit more work, however is most safe.