### PR TITLE
ApiKey as query parameters now picked up by security middleware

### DIFF
--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -213,7 +213,7 @@ class AuthValidator {
           throw Error(`'${scheme.name}' header required`);
         }
       } else if (scheme.in === 'query') {
-        if (!req.headers[scheme.name]) {
+        if (!req.query[scheme.name]) {
           throw Error(`query parameter '${scheme.name}' required`);
         }
       }

--- a/test/resources/security.top.level.yaml
+++ b/test/resources/security.top.level.yaml
@@ -6,7 +6,6 @@ info:
 
 servers:
   - url: /v1/
-
 security:
   - ApiKeyAuth: []
 
@@ -24,6 +23,16 @@ paths:
       security:
         - ApiKeyAuth: []
         - {}
+      responses:
+        '200':
+          description: OK
+        '401':
+          description: unauthorized
+
+  /api_query_key:
+    get:
+      security:
+        - ApiKeyQueryAuth: []
       responses:
         '200':
           description: OK
@@ -64,6 +73,10 @@ components:
       type: apiKey
       in: header
       name: X-API-Key
+    ApiKeyQueryAuth:
+      type: apiKey
+      in: query
+      name: APIKey
     BearerAuth:
       type: http
       scheme: bearer

--- a/test/security.top.level.spec.ts
+++ b/test/security.top.level.spec.ts
@@ -25,6 +25,7 @@ describe(packageJson.name, () => {
       express
         .Router()
         .get(`/api_key`, (req, res) => res.json({ logged_in: true }))
+        .get(`/api_query_key`, (req, res) => res.json({ logged_in: true }))
         .get(`/api_key_or_anonymous`, (req, res) =>
           res.json({ logged_in: true }),
         )
@@ -50,6 +51,13 @@ describe(packageJson.name, () => {
           "'X-API-Key' header required",
         );
       }));
+
+  it('should return 200 if apikey exist as queray param', async () =>
+    request(app)
+      .get(`${basePath}/api_query_key`)
+      .query({ "APIKey": 'test' })
+      .expect(200)
+  );
 
   it('should return 200 if apikey or anonymous', async () =>
     request(app)


### PR DESCRIPTION
Fix #92, we were looking in the headers not query param