### PR TITLE
add null value support to response validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ export class OpenApiValidator {
     const responseValidator = new middlewares.ResponseValidator(
       this.context.apiDoc,
       {
+        nullable: true,
         coerceTypes,
         removeAdditional,
         unknownFormats,

--- a/test/resources/response.validation.yaml
+++ b/test/resources/response.validation.yaml
@@ -101,6 +101,10 @@ components:
       required:
         - name
       properties:
+        bought_at:
+          type: string
+          format: date-time
+          nullable: true
         name:
           type: string
           nullable: true

--- a/test/response.validation.spec.ts
+++ b/test/response.validation.spec.ts
@@ -26,7 +26,7 @@ describe(packageJson.name, () => {
         });
         app.get(`${app.basePath}/pets`, (req, res) => {
           let json = {};
-          if ((req.query.mode == 'bad_type')) {
+          if (req.query.mode === 'bad_type') {
             json = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
           } else if (req.query.mode == 'check_null') {
             json = [

--- a/test/response.validation.spec.ts
+++ b/test/response.validation.spec.ts
@@ -6,6 +6,7 @@ import { createApp } from './common/app';
 
 const packageJson = require('../package.json');
 const apiSpecPath = path.join('test', 'resources', 'response.validation.yaml');
+const today = new Date();
 
 describe(packageJson.name, () => {
   let app = null;
@@ -25,8 +26,13 @@ describe(packageJson.name, () => {
         });
         app.get(`${app.basePath}/pets`, (req, res) => {
           let json = {};
-          if ((req.query.mode = 'bad_type')) {
+          if ((req.query.mode == 'bad_type')) {
             json = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
+          } else if (req.query.mode == 'check_null') {
+            json = [
+              { id: 1, name: 'name', tag: 'tag', bought_at: null },
+              { id: 2, name: 'name', tag: 'tag', bought_at: today.toISOString() },
+              { id: 3, name: 'name', tag: 'tag'}];
           }
           return res.json(json);
         });
@@ -97,6 +103,22 @@ describe(packageJson.name, () => {
         const e = r.body;
         expect(e.message).to.contain('should NOT have additional properties');
         expect(e.code).to.equal(500);
+      }));
+
+  it('should pass if value is null', async () =>
+    request(app)
+      .get(`${app.basePath}/pets?mode=check_null`)
+      .expect(200)
+      .then((r: any) => {
+        expect(r.body)
+          .is.an('array')
+          .with.length(3);
+        expect(r.body[0].bought_at)
+          .equal(null);
+        expect(r.body[1].bought_at)
+          .equal(today.toISOString());
+        expect(r.body[2].bought_at)
+          .to.be.undefined;
       }));
 
   it('should pass if response is a list', async () =>


### PR DESCRIPTION
Addressing the issues mentioned in: https://github.com/cdimascio/express-openapi-validator/issues/108

Null values were not valid in response objects. Instead values were being coerced to default for type according to AJV. So strings became `''` and numbers became `0`.

Added `nullable: true` to the options passed to AJV. This mimics the behavior of the request validator.

Also cleaned up an if statement checking equality using `=` instead of `==`.