### PR TITLE
Add basePath option to support custom basePath over server base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ new OpenApiValidator(options).install({
     ApiKeyAuth: (req, scopes, schema) => {
       throw { status: 401, message: 'sorry' }
     }
-  }
+  },
+  basePath: '/my/path'
 });
 ```
 
@@ -506,6 +507,15 @@ If `securityHandlers` are specified, the validator will validate against the Ope
 
     See [examples](https://github.com/cdimascio/express-openapi-validator/blob/security/test/security.spec.ts#L17) from unit tests
 
+
+### ▪️ basePath (optional)
+
+Specifies an optional custom base path to use for all routes. If not set, the base path(s) will be read from the `servers` property of the specification (see below).
+
+This is useful if the path of the public server URL in the API specification document differs from the path used by the backend server implementing the API.
+For example, even if the specification has a server URL of `http://my-app.com/api/admin`, an API gateway or proxy in front of the backend server might be forwarding requests without this path prefix, so that the backend server implements the routes directly on `/`.
+
+This can also be useful if one backend server implements multiple OpenAPI specifications for different paths using different Express sub-apps.
 
 ## The Base URL
 

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -56,11 +56,11 @@ export default class OpenAPIFramework implements IOpenAPIFramework {
     }
     this.apiDoc = copy(this.originalApiDoc);
 
-    this.basePaths = this.apiDoc.openapi
+    this.basePaths = !args.basePath && this.apiDoc.openapi
       ? getBasePathsFromServers(this.apiDoc.servers)
       : [
           new BasePath({
-            url: (this.apiDoc.basePath || '').replace(/\/$/, ''),
+            url: (args.basePath || this.apiDoc.basePath || '').replace(/\/$/, ''),
           }),
         ];
 

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -31,6 +31,7 @@ export interface OpenApiValidatorOpts {
   coerceTypes?: boolean;
   unknownFormats?: string[] | string | boolean;
   multerOpts?: {};
+  basePath?: string;
 }
 
 interface SecurityRequirement {
@@ -379,6 +380,7 @@ interface OpenAPIFrameworkArgs {
   routesIndexFileRegExp?: RegExp;
   validateApiDoc?: boolean;
   logger?: Logger;
+  basePath?: string;
 }
 
 export interface OpenAPIFrameworkAPIContext {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export class OpenApiValidator {
     this.options = options;
     this.context = new OpenApiContext({
       apiDoc: options.apiSpec,
+      basePath: options.basePath
     });
   }
 


### PR DESCRIPTION
Adding an option basePath used to customize the base path on which all routes are mounted.
By default, the base path is derived from the server(s) defined in the OpenAPI specification, but this option may be used if the backend server implementing the API is mounting the routes on another path.