### PR TITLE
Fix #117 Add top-level security schema to query whitelist

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -64,8 +64,19 @@ export class RequestValidator {
 
   private buildMiddleware(path, pathSchema, contentType) {
     const parameters = this.parametersToSchema(path, pathSchema.parameters);
+
+    let usedSecuritySchema = [];
+    if (pathSchema.hasOwnProperty('security')
+      && pathSchema.security.length > 0) {
+      usedSecuritySchema = pathSchema.security;
+    } else if (this._apiDocs.hasOwnProperty('security')
+      && this._apiDocs.security.length > 0) {
+      // if no security schema for the path, use top-level security schema
+      usedSecuritySchema = this._apiDocs.security;
+    }
+
     const securityQueryParameter = this.getSecurityQueryParams(
-      pathSchema,
+      usedSecuritySchema,
       this._apiDocs.components.securitySchemes,
     );
 
@@ -195,9 +206,9 @@ export class RequestValidator {
     return {};
   }
 
-  private getSecurityQueryParams(pathSchema, securitySchema) {
-    return pathSchema.security && securitySchema
-      ? pathSchema.security
+  private getSecurityQueryParams(usedSecuritySchema, securitySchema) {
+    return usedSecuritySchema && securitySchema
+      ? usedSecuritySchema
           .filter(obj => Object.entries(obj).length !== 0)
           .map(sec => {
             const securityKey = Object.keys(sec)[0];


### PR DESCRIPTION
My previous PR #112 added query parameter whitelisting for security query parameters.

There is an issue with my implementation since it is only using the security definition of the path. Query parameters of a top-level security definition are not covered by this.

This MR will take the top-level security definitions in case there are no security definitions for that path. 