### PR TITLE
Fix #124

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,9 +2457,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5193,9 +5193,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz",
-      "integrity": "sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -4,7 +4,7 @@ import mung from './modded.express.mung';
 import { createResponseAjv } from './ajv';
 import {
   augmentAjvErrors,
-  extractContentType,
+  ContentType,
   ajvErrorsToValidatorError,
   validationError,
 } from './util';
@@ -45,8 +45,8 @@ export class ResponseValidator {
       return this.buildValidators(responses);
     }
 
-    const contentType = extractContentType(req) || 'not_provided';
-    const key = `${req.method}-${req.originalUrl}-${contentType}`;
+    const contentTypeKey = ContentType.from(req).equivalents()[0] || 'not_provided';
+    const key = `${req.method}-${req.originalUrl}-${contentTypeKey}`;
 
     let validators = this.validatorsCache[key];
     if (!validators) {

--- a/src/middlewares/util.ts
+++ b/src/middlewares/util.ts
@@ -7,11 +7,16 @@ export class ContentType {
   private withoutBoundary: string = null;
   public contentType = null;
   public mediaType: string = null;
+  public charSet: string = null;
   private constructor(contentType: string | null) {
     this.contentType = contentType;
     if (contentType) {
       this.withoutBoundary = contentType.replace(/;\s{0,}boundary.*/, '');
       this.mediaType = this.withoutBoundary.split(';')[0].trim();
+      this.charSet = this.withoutBoundary.split(';')[1];
+      if (this.charSet) {
+        this.charSet = this.charSet.trim();
+      }
     }
   }
   static from(req: Request): ContentType {
@@ -20,10 +25,10 @@ export class ContentType {
 
   equivalents(): string[] {
     if (!this.withoutBoundary) return [];
-    if (this.mediaType === 'application/json') {
-      return ['application/json', 'application/json; charset=utf-8'];
+    if (this.charSet) {
+      return [this.mediaType, `${this.mediaType}; ${this.charSet}`];
     }
-    return [this.withoutBoundary];
+    return [this.withoutBoundary, `${this.mediaType}; charset=utf-8`];
   }
 }
 

--- a/src/middlewares/util.ts
+++ b/src/middlewares/util.ts
@@ -8,12 +8,27 @@ export function extractContentType(req: Request): string | null {
   if (!contentType) {
     return null;
   }
+  if (contentType.match(/charset/)) {
+    // if contentType has charset such as 'application.json; charset=utf-8',
+    // will use raw value of contentType
+    return contentType;
+  } else {
+    // if doesn't, will use media-type only in contentType by dropping any characters after semicolon.
+    return extractMediaType(contentType)
+  }
+}
+
+function extractMediaType(contentType: string | null): string | null {
+  if (!contentType) {
+    return null;
+  }
   let end = contentType.indexOf(';');
   end = end === -1 ? contentType.length : end;
   if (contentType) {
     return contentType.substring(0, end);
+  } else {
+    return contentType
   }
-  return contentType;
 }
 
 const _validationError = (

--- a/test/common/app.common.ts
+++ b/test/common/app.common.ts
@@ -102,4 +102,12 @@ export function routes(app) {
       metadata: req.body.metadata,
     });
   });
+  app.post('/v1/pets_charset', function (req, res, next) {
+    // req.file is the `avatar` file
+    // req.body will hold the text fields, if there were any
+    res.json({
+      ...req.body,
+      id: 'new-id',
+    });
+  });
 }

--- a/test/common/app.common.ts
+++ b/test/common/app.common.ts
@@ -102,7 +102,7 @@ export function routes(app) {
       metadata: req.body.metadata,
     });
   });
-  app.post('/v1/pets_charset', function (req, res, next) {
+  app.post('/v1/pets_charset', function (req, res) {
     // req.file is the `avatar` file
     // req.body will hold the text fields, if there were any
     res.json({

--- a/test/common/app.common.ts
+++ b/test/common/app.common.ts
@@ -102,7 +102,7 @@ export function routes(app) {
       metadata: req.body.metadata,
     });
   });
-  app.post('/v1/pets_charset', function (req, res) {
+  app.post('/v1/pets_charset', function (req: Request, res: any) {
     // req.file is the `avatar` file
     // req.body will hold the text fields, if there were any
     res.json({

--- a/test/headers.spec.ts
+++ b/test/headers.spec.ts
@@ -29,4 +29,17 @@ describe(packageJson.name, () => {
         expect(e).to.have.length(1);
         expect(e[0].path).to.equal('.headers.x-attribute-id');
       }));
+
+      describe(`POST .../pets`, () => {
+        it('should find appropriate request body in spec by contentType with charset', async () =>
+          request(app)
+            .post(`${app.basePath}/pets_charset`)
+            .set('Content-Type', 'application/json; charset=utf-8')
+            .set('Accept', 'application/json; charset=utf-8')
+            .send({
+              name: "myPet",
+              tag: "cat",
+            })
+            .expect(200));
+        })
 });

--- a/test/headers.spec.ts
+++ b/test/headers.spec.ts
@@ -7,14 +7,21 @@ import * as packageJson from '../package.json';
 describe(packageJson.name, () => {
   let app = null;
 
-  before(() => {
+  /** 
+   * Required to create app for each step, since 'buildMiddleware' is cached by media-type in contentType.
+   * So without Each, if 'buildMiddleware' is cached at the previous request with 'application/json',
+   * following request with 'application/json; charset = utf-8' won't be evaluated.
+   * To avoid any potential error, use beforeEach and afterEach.
+   * 
+   * */
+  beforeEach(() => {
     const apiSpec = path.join('test', 'resources', 'openapi.yaml');
     return createApp({ apiSpec }, 3004).then(a => {
       app = a;
     });
   });
 
-  after(() => {
+  afterEach(() => {
     (<any>app).server.close();
   });
 

--- a/test/headers.spec.ts
+++ b/test/headers.spec.ts
@@ -30,16 +30,28 @@ describe(packageJson.name, () => {
         expect(e[0].path).to.equal('.headers.x-attribute-id');
       }));
 
-      describe(`POST .../pets`, () => {
-        it('should find appropriate request body in spec by contentType with charset', async () =>
-          request(app)
-            .post(`${app.basePath}/pets_charset`)
-            .set('Content-Type', 'application/json; charset=utf-8')
-            .set('Accept', 'application/json; charset=utf-8')
-            .send({
-              name: "myPet",
-              tag: "cat",
-            })
-            .expect(200));
+  describe(`POST .../pets`, () => {
+    it('should find appropriate request body in spec by contentType with charset (compatibility)', async () =>
+      request(app)
+        .post(`${app.basePath}/pets_charset`)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .send({
+          name: "myPet",
+          tag: "cat",
         })
+        .expect(200));
+    
+    it('should find appropriate request body in spec by contentType with charset', async () =>
+      request(app)
+        .post(`${app.basePath}/pets_charset`)
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .set('Accept', 'application/json; charset=utf-8')
+        .send({
+          name: "myPet",
+          tag: "cat",
+        })
+        .expect(200));
+  })
+
 });

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -82,17 +82,4 @@ describe(packageJson.name, () => {
             .equal('unsupported media type application/json');
         }));
   });
-  describe(`POST .../pets`, () => {
-    it('should find appropriate request body in spec by contentType with charset', async () =>
-      request(app)
-        .post(`${app.basePath}/pets_charset`)
-        .set('Content-Type', 'application/json; charset=utf-8')
-        .set('Accept', 'application/json; charset=utf-8')
-        .send({
-          name: "myPet",
-          tag: "cat",
-        })
-        .expect(200));
-    })
-
 });

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -90,7 +90,7 @@ describe(packageJson.name, () => {
         .set('Accept', 'application/json; charset=utf-8')
         .send({
           name: "myPet",
-          tag: "cat"
+          tag: "cat",
         })
         .expect(200));
     })

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -5,18 +5,15 @@ import { createApp } from './common/app';
 import * as packageJson from '../package.json';
 
 describe(packageJson.name, () => {
+  let app = null;
+  before(async () => {
+    const apiSpec = path.join('test', 'resources', 'openapi.yaml');
+    app = await createApp({ apiSpec }, 3003);
+  });
+  after(() => {
+    (<any>app).server.close();
+  });
   describe(`GET .../pets/:id/photos`, () => {
-    let app = null;
-
-    before(async () => {
-      const apiSpec = path.join('test', 'resources', 'openapi.yaml');
-      app = await createApp({ apiSpec }, 3003);
-    });
-
-    after(() => {
-      (<any>app).server.close();
-    });
-
     it('should throw 400 when required multipart file field', async () =>
       request(app)
         .post(`${app.basePath}/pets/10/photos`)
@@ -85,4 +82,17 @@ describe(packageJson.name, () => {
             .equal('unsupported media type application/json');
         }));
   });
+  describe(`POST .../pets`, () => {
+    it('should find appropriate request body in spec by contentType with charset', async () =>
+      request(app)
+        .post(`${app.basePath}/pets_charset`)
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .set('Accept', 'application/json; charset=utf-8')
+        .send({
+          name: "myPet",
+          tag: "cat"
+        })
+        .expect(200));
+    })
+
 });

--- a/test/resources/openapi.yaml
+++ b/test/resources/openapi.yaml
@@ -324,9 +324,6 @@ paths:
           application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/NewPet'
-          application/xml; charset=utf-8:
-            schema:
-              $ref: '#/components/schemas/NewPet'
       responses:
         '200':
           description: pet response

--- a/test/resources/openapi.yaml
+++ b/test/resources/openapi.yaml
@@ -313,6 +313,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /pets_charset:
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   parameters:

--- a/test/resources/openapi.yaml
+++ b/test/resources/openapi.yaml
@@ -324,6 +324,9 @@ paths:
           application/json; charset=utf-8:
             schema:
               $ref: '#/components/schemas/NewPet'
+          application/xml; charset=utf-8:
+            schema:
+              $ref: '#/components/schemas/NewPet'
       responses:
         '200':
           description: pet response


### PR DESCRIPTION
**[Objective]**
To allow `charset` in content-type header.

**[Related Issue]**
#124 

**[Note]**
Since the `boundary` will be automatically filled, we should drop as before.