### PR TITLE
Fix $ref issue  with special characters (#183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,10 +331,11 @@ new OpenApiValidator(options).install({
         throw { status: 401, message: 'sorry' }
       }
     }
-  }
-  ignorePaths: /.*\/pets$/
+  },
+  ignorePaths: /.*\/pets$/,
   unknownFormats: ['phone-number', 'uuid'],
   multerOpts: { ... },
+  unsafeRefs: false
 });
 ```
 
@@ -460,6 +461,15 @@ Determines whether the validator should coerce value types to match the type def
 - `true` (**default**) - coerce scalar data types.
 - `false` - no type coercion.
 - `"array"` - in addition to coercions between scalar types, coerce scalar data to an array with one element and vice versa (as required by the schema).
+
+### ▪️ unsafeRefs (optional)
+
+As express-openapi-validator uses internally [json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser), two choices are possibles :
+
+- `false` **(default)** - It will use the `bundle` method (which prevent circular references issues)
+- `true` - It will use the `dereference` method (which may be needed if you split your specifications into many files and use escaped characters in your [$refs](https://swagger.io/docs/specification/using-ref/))
+
+See this [issue](https://github.com/APIDevTools/json-schema-ref-parser/issues/101#issuecomment-421755168) for more information.
 
 ## The Base URL
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,9 @@ new OpenApiValidator(options).install({
   ignorePaths: /.*\/pets$/,
   unknownFormats: ['phone-number', 'uuid'],
   multerOpts: { ... },
-  unsafeRefs: false
+  $refParser: { 
+    mode: 'bundle'
+  }
 });
 ```
 
@@ -462,12 +464,12 @@ Determines whether the validator should coerce value types to match the type def
 - `false` - no type coercion.
 - `"array"` - in addition to coercions between scalar types, coerce scalar data to an array with one element and vice versa (as required by the schema).
 
-### ▪️ unsafeRefs (optional)
+### ▪️ $refParser.mode (optional)
 
 As express-openapi-validator uses internally [json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser), two choices are possibles :
 
-- `false` **(default)** - It will use the `bundle` method (which prevent circular references issues)
-- `true` - It will use the `dereference` method (which may be needed if you split your specifications into many files and use escaped characters in your [$refs](https://swagger.io/docs/specification/using-ref/))
+- `bundle` **(default)** - It will use the `bundle` method (which prevent circular references issues)
+- `dereference` - It will use the `dereference` method (which may be needed if you split your specifications into many files and use escaped characters in your [$refs](https://swagger.io/docs/specification/using-ref/))
 
 See this [issue](https://github.com/APIDevTools/json-schema-ref-parser/issues/101#issuecomment-421755168) for more information.
 

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -71,7 +71,7 @@ export class OpenAPIFramework {
     };
   }
 
-  private loadSpec(filePath: string | object, $refParser: { mode: 'bundle' | 'dereference' }): Promise<OpenAPIV3.Document> {
+  private loadSpec(filePath: string | object, $refParser: { mode: 'bundle' | 'dereference' } = { mode: 'bundle'}): Promise<OpenAPIV3.Document> {
     // Because of this issue ( https://github.com/APIDevTools/json-schema-ref-parser/issues/101#issuecomment-421755168 )
     // We need this workaround ( use '$RefParser.dereference' instead of '$RefParser.bundle' ) if asked by user
     if (typeof filePath === 'string') {

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -71,7 +71,9 @@ export class OpenAPIFramework {
     };
   }
 
-  private loadSpec(filePath: string | object, $refParser: { mode: 'bundle' | 'dereference' } = { mode: 'bundle'}): Promise<OpenAPIV3.Document> {
+  private loadSpec(
+    filePath: string | object,
+    $refParser: { mode: 'bundle' | 'dereference' } = { mode: 'bundle' }): Promise<OpenAPIV3.Document> {
     // Because of this issue ( https://github.com/APIDevTools/json-schema-ref-parser/issues/101#issuecomment-421755168 )
     // We need this workaround ( use '$RefParser.dereference' instead of '$RefParser.bundle' ) if asked by user
     if (typeof filePath === 'string') {
@@ -86,7 +88,7 @@ export class OpenAPIFramework {
             fs.readFileSync(absolutePath, 'utf8'),
             { json: true },
           );
-          return ($refParser.mode === "bundle") ? $RefParser.bundle(docWithRefs) : $RefParser.dereference(docWithRefs);
+          return ($refParser.mode === 'bundle') ? $RefParser.bundle(docWithRefs) : $RefParser.dereference(docWithRefs);
         } finally {
           process.chdir(origCwd);
         }
@@ -96,7 +98,7 @@ export class OpenAPIFramework {
         );
       }
     }
-    return ($refParser.mode === "bundle") ? $RefParser.bundle(filePath) : $RefParser.dereference(filePath);
+    return ($refParser.mode === 'bundle') ? $RefParser.bundle(filePath) : $RefParser.dereference(filePath);
   }
 
   private copy<T>(obj: T): T {

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -72,6 +72,8 @@ export class OpenAPIFramework {
   }
 
   private loadSpec(filePath: string | object): Promise<OpenAPIV3.Document> {
+    // Because of this issue ( https://github.com/APIDevTools/json-schema-ref-parser/issues/101#issuecomment-421755168 )
+    // We need this workaround ( use '$RefParser.dereference' instead of '$RefParser.bundle' )
     if (typeof filePath === 'string') {
       const origCwd = process.cwd();
       const specDir = path.resolve(origCwd, path.dirname(filePath));
@@ -84,7 +86,7 @@ export class OpenAPIFramework {
             fs.readFileSync(absolutePath, 'utf8'),
             { json: true },
           );
-          return $RefParser.bundle(docWithRefs);
+          return $RefParser.dereference(docWithRefs);
         } finally {
           process.chdir(origCwd);
         }
@@ -94,7 +96,7 @@ export class OpenAPIFramework {
         );
       }
     }
-    return $RefParser.bundle(filePath);
+    return $RefParser.dereference(filePath);
   }
 
   private copy<T>(obj: T): T {

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -23,7 +23,7 @@ export class OpenAPIFramework {
     visitor: OpenAPIFrameworkVisitor,
   ): Promise<OpenAPIFrameworkInit> {
     const args = this.args;
-    const apiDoc = await this.copy(await this.loadSpec(args.apiDoc, args.unsafeRefs));
+    const apiDoc = await this.copy(await this.loadSpec(args.apiDoc, args.$refParser));
     const basePathObs = this.getBasePathsFromServers(apiDoc.servers);
     const basePaths = Array.from(
       basePathObs.reduce((acc, bp) => {
@@ -71,7 +71,7 @@ export class OpenAPIFramework {
     };
   }
 
-  private loadSpec(filePath: string | object, unsafeRefs: boolean): Promise<OpenAPIV3.Document> {
+  private loadSpec(filePath: string | object, $refParser: { mode: 'bundle' | 'dereference' }): Promise<OpenAPIV3.Document> {
     // Because of this issue ( https://github.com/APIDevTools/json-schema-ref-parser/issues/101#issuecomment-421755168 )
     // We need this workaround ( use '$RefParser.dereference' instead of '$RefParser.bundle' ) if asked by user
     if (typeof filePath === 'string') {
@@ -86,7 +86,7 @@ export class OpenAPIFramework {
             fs.readFileSync(absolutePath, 'utf8'),
             { json: true },
           );
-          return (!unsafeRefs) ? $RefParser.bundle(docWithRefs) : $RefParser.dereference(docWithRefs);
+          return ($refParser.mode === "bundle") ? $RefParser.bundle(docWithRefs) : $RefParser.dereference(docWithRefs);
         } finally {
           process.chdir(origCwd);
         }
@@ -96,7 +96,7 @@ export class OpenAPIFramework {
         );
       }
     }
-    return (!unsafeRefs) ? $RefParser.bundle(filePath) : $RefParser.dereference(filePath);
+    return ($refParser.mode === "bundle") ? $RefParser.bundle(filePath) : $RefParser.dereference(filePath);
   }
 
   private copy<T>(obj: T): T {

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -71,7 +71,7 @@ export class OpenAPIFramework {
     };
   }
 
-  private loadSpec(filePath: string | object, unsafeRefs: boolean = false): Promise<OpenAPIV3.Document> {
+  private loadSpec(filePath: string | object, unsafeRefs: boolean): Promise<OpenAPIV3.Document> {
     // Because of this issue ( https://github.com/APIDevTools/json-schema-ref-parser/issues/101#issuecomment-421755168 )
     // We need this workaround ( use '$RefParser.dereference' instead of '$RefParser.bundle' ) if asked by user
     if (typeof filePath === 'string') {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -40,7 +40,9 @@ export interface OpenApiValidatorOpts {
   coerceTypes?: boolean | 'array';
   unknownFormats?: true | string[] | 'ignore';
   multerOpts?: {};
-  unsafeRefs?: boolean;
+  $refParser?: {
+    mode: 'bundle' | 'dereference'
+  };
 }
 
 export namespace OpenAPIV3 {
@@ -360,7 +362,9 @@ export interface OpenAPIFrameworkPathObject {
 interface OpenAPIFrameworkArgs {
   apiDoc: OpenAPIV3.Document | string;
   validateApiDoc?: boolean;
-  unsafeRefs?: boolean;
+  $refParser?: {
+    mode: 'bundle' | 'dereference'
+  };
 }
 
 export interface OpenAPIFrameworkAPIContext {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -40,7 +40,7 @@ export interface OpenApiValidatorOpts {
   coerceTypes?: boolean | 'array';
   unknownFormats?: true | string[] | 'ignore';
   multerOpts?: {};
-  unsafeRefs?: boolean
+  unsafeRefs?: boolean;
 }
 
 export namespace OpenAPIV3 {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -40,6 +40,7 @@ export interface OpenApiValidatorOpts {
   coerceTypes?: boolean | 'array';
   unknownFormats?: true | string[] | 'ignore';
   multerOpts?: {};
+  unsafeRefs?: boolean
 }
 
 export namespace OpenAPIV3 {
@@ -359,6 +360,7 @@ export interface OpenAPIFrameworkPathObject {
 interface OpenAPIFrameworkArgs {
   apiDoc: OpenAPIV3.Document | string;
   validateApiDoc?: boolean;
+  unsafeRefs?: boolean;
 }
 
 export interface OpenAPIFrameworkAPIContext {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -41,7 +41,7 @@ export interface OpenApiValidatorOpts {
   unknownFormats?: true | string[] | 'ignore';
   multerOpts?: {};
   $refParser?: {
-    mode: 'bundle' | 'dereference'
+    mode: 'bundle' | 'dereference',
   };
 }
 

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -363,7 +363,7 @@ interface OpenAPIFrameworkArgs {
   apiDoc: OpenAPIV3.Document | string;
   validateApiDoc?: boolean;
   $refParser?: {
-    mode: 'bundle' | 'dereference'
+    mode: 'bundle' | 'dereference',
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export class OpenApiValidator {
     if (options.validateRequests == null) options.validateRequests = true;
     if (options.validateResponses == null) options.validateResponses = false;
     if (options.validateSecurity == null) options.validateSecurity = true;
-    if (options.unsafeRefs == null) options.unsafeRefs = false;
+    if (options.$refParser == null) options.$refParser = {mode: 'bundle'};
 
     if (options.validateResponses === true) {
       options.validateResponses = {
@@ -63,7 +63,7 @@ export class OpenApiValidator {
   ): Promise<void> | void {
     const p = new OpenApiSpecLoader({
       apiDoc: this.options.apiSpec,
-      unsafeRefs: this.options.unsafeRefs,
+      $refParser: this.options.$refParser,
     })
       .load()
       .then(spec => this.installMiddleware(app, spec));

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export class OpenApiValidator {
   ): Promise<void> | void {
     const p = new OpenApiSpecLoader({
       apiDoc: this.options.apiSpec,
-      unsafeRefs: this.options.unsafeRefs
+      unsafeRefs: this.options.unsafeRefs,
     })
       .load()
       .then(spec => this.installMiddleware(app, spec));

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export class OpenApiValidator {
     if (options.validateRequests == null) options.validateRequests = true;
     if (options.validateResponses == null) options.validateResponses = false;
     if (options.validateSecurity == null) options.validateSecurity = true;
+    if (options.unsafeRefs == null) options.unsafeRefs = false;
 
     if (options.validateResponses === true) {
       options.validateResponses = {
@@ -62,6 +63,7 @@ export class OpenApiValidator {
   ): Promise<void> | void {
     const p = new OpenApiSpecLoader({
       apiDoc: this.options.apiSpec,
+      unsafeRefs: this.options.unsafeRefs
     })
       .load()
       .then(spec => this.installMiddleware(app, spec));
@@ -234,7 +236,7 @@ export class OpenApiValidator {
   }
 
   private normalizeOptions(options: OpenApiValidatorOpts): void {
-    // Modify the recquest
+    // Modify the request
     if (options.securityHandlers) {
       options.validateSecurity = {
         handlers: options.securityHandlers,

--- a/test/escaped.characters.in.ref.path.spec.ts
+++ b/test/escaped.characters.in.ref.path.spec.ts
@@ -10,7 +10,7 @@ describe(packageJson.name, () => {
   before(async () => {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'escaped.characters.in.path.yaml');
-    app = await createApp({ apiSpec, unsafeRefs: true }, 3005, app => {
+    app = await createApp({ apiSpec, $refParser: {mode: 'dereference'} }, 3005, app => {
       app.use(
         `${app.basePath}`,
         express

--- a/test/escaped.characters.in.ref.path.spec.ts
+++ b/test/escaped.characters.in.ref.path.spec.ts
@@ -1,0 +1,61 @@
+import * as path from 'path';
+import * as express from 'express';
+import * as request from 'supertest';
+import { createApp } from './common/app';
+import * as packageJson from '../package.json';
+
+describe(packageJson.name, () => {
+  let app = null;
+
+  before(async () => {
+    // Set up the express app
+    const apiSpec = path.join('test', 'resources', 'escaped.characters.in.path.yaml');
+    app = await createApp({ apiSpec, unsafeRefs: true }, 3005, app => {
+      app.use(
+        `${app.basePath}`,
+        express
+          .Router()
+          .post(`/auth/login`, (req, res) => res.json({
+            'token': 'SOME_JWT_TOKEN',
+            'user': {
+              'fullName': 'Eric Cartman',
+              'role': 'admin',
+            },
+          })),
+      );
+      app.use(
+        `${app.basePath}`,
+        express
+          .Router()
+          .post(`/auth/register`, (req, res) => res.status(200).end()),
+      );
+    });
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  // Without option "unsafeRefs" this test will fail
+  it('should be able to use an endpoint with some nested paths $ref ', async () =>
+    request(app)
+      .post(`${app.basePath}/auth/register`)
+      .send({
+        email: 'jy95@perdu.com',
+        password: '123456',
+        fullName: 'Eric Cartman',
+      })
+      .expect(200),
+  );
+
+  it('should be able to use an endpoint with some nested paths $ref 2', async () =>
+    request(app)
+      .post(`${app.basePath}/auth/login`)
+      .send({
+        email: 'jy95@perdu.com',
+        password: '123456',
+      })
+      .expect(200),
+  );
+
+});

--- a/test/resources/escaped.characters.in.path.yaml
+++ b/test/resources/escaped.characters.in.path.yaml
@@ -1,0 +1,35 @@
+openapi: '3.0.0'
+info:
+  description: "Some escaped characters in $ref"
+  version: "1.0.0"
+  title: "Source Code"
+  license:
+    name: "GPL-3.0-or-later"
+    url: "https://choosealicense.com/licenses/gpl-3.0/"
+
+servers:
+  - url: /v1/
+
+paths:
+  /auth/login:
+    $ref: 'sub_files/paths/auth.yaml#/paths/~1auth~1login'
+  /auth/register:
+    $ref: 'sub_files/paths/auth.yaml#/paths/~1auth~1register'
+
+# Needed since https://github.com/cdimascio/express-openapi-validator/pull/189 is not merged yet
+components:
+  schemas:
+    ErrorObject:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The main error message ( for example "Bad Request", "Unauthorized", etc. )
+        errors:
+          type: array
+          items:
+            type: object
+            description: Explanation about an error
+      required:
+        - message
+        - errors

--- a/test/resources/sub_files/paths/auth.yaml
+++ b/test/resources/sub_files/paths/auth.yaml
@@ -1,0 +1,121 @@
+paths:
+  /auth/login:
+    post:
+      summary: "Logs user into the system"
+      operationId: signIn
+      tags:
+        - guest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Auth"
+      responses:
+        '200':
+          description: A JSON containing the JWT Token and some information about the user
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JWTToken"
+                  - type: object
+                    description: Some basic information on this user
+                    properties:
+                      user:
+                        type: object
+                        properties:
+                          fullName:
+                            type: string
+                            description: "The full name of this user"
+                            example: "Eric Cartman"
+                            minLength: 1
+                            maxLength: 50
+                          role:
+                            type: string
+                            enum: [admin, user]
+                            description: "What kind of user are we ?"
+                        required:
+                          - fullName
+                          - role
+                    required:
+                      - user
+        # Definition of all error statuses
+        default:
+          description: "Whatever error : 4XX - Client error (Bad Request, Unauthorized, etc.) , 5XX - Server error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorObject"
+  /auth/register:
+    post:
+      summary: "Creates a new user into the system"
+      operationId: register
+      tags:
+        - guest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/Auth"
+                - type: object
+                  properties:
+                    fullName:
+                      type: string
+                      example: "Some User"
+                      description: "The full name of this new user"
+                      minLength: 1
+                      maxLength: 50
+                  required:
+                    - fullName
+      responses:
+        '200':
+          description: OK
+        # Definition of all error statuses
+        default:
+          description: "Whatever error : 4XX - Client error (Bad Request, Unauthorized, etc.) , 5XX - Server error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorObject"
+
+components:
+  schemas:
+    Auth:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          example: "jy95@perdu.com"
+        password:
+          type: string
+          format: password
+          example: "42"
+      required:
+        - email
+        - password
+    JWTToken:
+      type: object
+      properties:
+        token:
+          type: string
+          description: The JWT Token
+      required:
+        - token
+    ErrorObject:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The main error message ( for example "Bad Request", "Unauthorized", etc. )
+        errors:
+          type: array
+          items:
+            type: object
+            description: Explanation about an error
+      required:
+        - message
+        - errors


### PR DESCRIPTION
Attempt to fix #183 .
In my opinion ( as some of the tests uses circular structure ) , it is better to give choice to final user to use dereference / bundle if they got a similar situation like mine.

For example : 
```js
new OpenApiValidator({
    unsafeRefs: true
}).install(app)
```