### PR TITLE
Only enforce query object parsing when specified, always validate #186

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -372,7 +372,7 @@ export class RequestValidator {
             [].concat(
               schema.allOf,
               schema.oneOf,
-              schema.anyOf,
+              schema.anyOf
             ).some(schemaHasObject)
           );
 

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -366,21 +366,15 @@ export class RequestValidator {
         }
       } else if ($in === 'query') {
         // handle complex json types in schema
-        const schemaHasObject = schema => {
-          return (
-            schema.type === 'object' &&
-            schema.type !== 'array'
-          ) || (
-            schema.allOf &&
-            schema.allOf.some(schemaHasObject)
-          ) || (
-            schema.oneOf &&
-            schema.oneOf.some(schemaHasObject)
-          ) || (
-            schema.anyOf &&
-            schema.anyOf.some(schemaHasObject)
-          )
-        };
+        const schemaHasObject = schema =>
+          schema && (
+            schema.type === 'object' ||
+            [].concat(
+              schema.allOf,
+              schema.oneOf,
+              schema.anyOf,
+            ).some(schemaHasObject)
+          );
 
         if (schemaHasObject(parameterSchema)) {
           parseJson.push({ name, reqField });

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -153,9 +153,14 @@ export class RequestValidator {
        */
       parameters.parseJson.forEach(item => {
         if (req[item.reqField]?.[item.name]) {
-          req[item.reqField][item.name] = JSON.parse(
-            req[item.reqField][item.name],
-          );
+          try {
+            req[item.reqField][item.name] = JSON.parse(
+              req[item.reqField][item.name],
+            );
+          } catch (e) {
+              // NOOP If parsing failed but _should_ contain JSON, validator will catch it.
+              // May contain falsely flagged parameter (e.g. input was object OR string)
+          }
         }
       });
 
@@ -359,16 +364,27 @@ export class RequestValidator {
         ) {
           parseJson.push({ name, reqField });
         }
-      } else if (
+      } else if ($in === 'query') {
         // handle complex json types in schema
-        $in === 'query' &&
-        (parameterSchema.allOf ||
-          parameterSchema.oneOf ||
-          parameterSchema.anyOf ||
-          (parameterSchema.type === 'object' &&
-            parameterSchema.type !== 'array'))
-      ) {
-        parseJson.push({ name, reqField });
+        const schemaHasObject = schema => {
+          return (
+            schema.type === 'object' &&
+            schema.type !== 'array'
+          ) || (
+            schema.allOf &&
+            schema.allOf.some(schemaHasObject)
+          ) || (
+            schema.oneOf &&
+            schema.oneOf.some(schemaHasObject)
+          ) || (
+            schema.anyOf &&
+            schema.anyOf.some(schemaHasObject)
+          )
+        };
+
+        if (schemaHasObject(parameterSchema)) {
+          parseJson.push({ name, reqField });
+        }
       }
 
       if (!parameterSchema) {

--- a/test/resources/serialized.objects.yaml
+++ b/test/resources/serialized.objects.yaml
@@ -2,12 +2,12 @@
 openapi: '3.0.2'
 info:
   version: 1.0.0
-  title: requestBodies $ref
-  description: requestBodies $ref Test
+  title: Request Query Serialization
+  description: Request Query Serialization Test
 
 servers:
   - url: /v1/
-  
+
 paths:
   /serialisable:
     get:
@@ -16,6 +16,7 @@ paths:
         - in: query
           style: form
           name: settings
+          description: Should be serialized
           explode: true
           schema:
             allOf:
@@ -32,21 +33,41 @@ paths:
                       type: integer
                       minimum: 0
                       example: 42
+        - in: query
+          name: timestamp
+          description: Should not be serialized
+          schema:
+            description: Value passed to Javascript's `new Date()`.
+            example: '2019-06-24T12:34:56.789Z'
+            anyOf:
+              - type: integer
+                description: Unix milliseconds
+                example: 1234567890123
+                nullable: true
+              - type: string
+                description: ISO Timestamp
+                pattern: \S
+        - in: query
+          name: fooBar
+          description: Should be serialized if an object
+          schema:
+            oneOf:
+              - type: string
+                pattern: fooBar
+              - type: object
+                properties:
+                  foo:
+                    type: string
+                    pattern: bar
+                additionalProperties: false
+                required:
+                  - foo
       responses:
         '200':
-          description: "An array of items"
+          description: parsed & validated query params
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/someItem"
-                uniqueItems: true
-                
-components:
-  schemas:
-    someItem:
-      type: object
-      properties:
-        id:
-          type: string
+                type: object
+
+components: {}

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as express from 'express';
 import * as request from 'supertest';
 import * as packageJson from '../package.json';
+import { expect } from 'chai';
 import { createApp } from './common/app';
 
 describe(packageJson.name, () => {
@@ -15,7 +16,7 @@ describe(packageJson.name, () => {
         `${app.basePath}`,
         express
           .Router()
-          .get(`/serialisable`, (req, res) => res.json({ id: 'test' })),
+          .get(`/serialisable`, (req, res) => res.json(req.query)),
       ),
     );
   });
@@ -29,6 +30,49 @@ describe(packageJson.name, () => {
       .get(`${app.basePath}/serialisable`)
       .query({
         settings: '{"onlyValidated":true}',
+        timestamp: '2019-06-24T12:34:56.789Z',
+        fooBar: '{"foo":"bar"}',
       })
-      .expect(200));
+      .expect(200)
+      .then(response => {
+        expect(response.body).to.deep.equal({
+          settings: {
+            onlyValidated: true,
+            onlySelected: [],
+          },
+          timestamp: '2019-06-24T12:34:56.789Z',
+          fooBar: {
+            foo: 'bar',
+          },
+        });
+      })
+  );
+
+  it('should not deserialize when non-object', async () =>
+    request(app)
+      .get(`${app.basePath}/serialisable`)
+      .query({
+        timestamp: 1234567890123,
+        fooBar: 'fooBar',
+      })
+      .expect(200)
+      .then(response => {
+        expect(response.body).to.deep.equal({
+          timestamp: 1234567890123,
+          fooBar: 'fooBar',
+        });
+      })
+  );
+
+  it('should fail on validation, not parsing', async () =>
+    request(app)
+      .get(`${app.basePath}/serialisable`)
+      .query({
+        settings: 'this is not valid json'
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body.message).to.equal('request.query.settings should be object');
+      })
+  );
 });

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -34,9 +34,8 @@ describe(packageJson.name, () => {
         fooBar: '{"foo":"bar"}',
       })
       .expect(200)
-      .then((r: any) => {
-        const e = r.body;
-        expect(e).to.deep.equal({
+      .then(response => {
+        expect(response.body).to.deep.equal({
           settings: {
             onlyValidated: true,
             onlySelected: [],
@@ -57,9 +56,8 @@ describe(packageJson.name, () => {
         fooBar: 'fooBar',
       })
       .expect(200)
-      .then((r: any) => {
-        const e = r.body;
-        expect(e).to.deep.equal({
+      .then(response => {
+        expect(response.body).to.deep.equal({
           timestamp: 1234567890123,
           fooBar: 'fooBar',
         });
@@ -73,9 +71,8 @@ describe(packageJson.name, () => {
         settings: 'this is not valid json',
       })
       .expect(400)
-      .then((r: any) => {
-        const e = r.body;
-        expect(e.message).to.equal('request.query.settings should be object');
-      }),
+      .then(response => {
+        expect(response.body.message).to.equal('request.query.settings should be object');
+      })
   );
 });

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -71,8 +71,8 @@ describe(packageJson.name, () => {
         settings: 'this is not valid json',
       })
       .expect(400)
-      .then(response => {
-        expect(response.body.message).to.equal('request.query.settings should be object');
-      })
+      .then(response =>
+        expect(response.body.message).to.equal('request.query.settings should be object')
+      )
   );
 });

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -45,8 +45,7 @@ describe(packageJson.name, () => {
             foo: 'bar',
           },
         });
-      })
-  );
+      }));
 
   it('should not deserialize when non-object', async () =>
     request(app)
@@ -61,8 +60,7 @@ describe(packageJson.name, () => {
           timestamp: 1234567890123,
           fooBar: 'fooBar',
         });
-      })
-  );
+      }));
 
   it('should fail on validation, not parsing', async () =>
     request(app)
@@ -73,6 +71,5 @@ describe(packageJson.name, () => {
       .expect(400)
       .then(response => {
         expect(response.body.message).to.equal('request.query.settings should be object');
-      })
-  );
+      }));
 });

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -34,8 +34,9 @@ describe(packageJson.name, () => {
         fooBar: '{"foo":"bar"}',
       })
       .expect(200)
-      .then(response => {
-        expect(response.body).to.deep.equal({
+      .then((r: any) => {
+        const e = r.body;
+        expect(e).to.deep.equal({
           settings: {
             onlyValidated: true,
             onlySelected: [],
@@ -56,8 +57,9 @@ describe(packageJson.name, () => {
         fooBar: 'fooBar',
       })
       .expect(200)
-      .then(response => {
-        expect(response.body).to.deep.equal({
+      .then((r: any) => {
+        const e = r.body;
+        expect(e).to.deep.equal({
           timestamp: 1234567890123,
           fooBar: 'fooBar',
         });
@@ -71,8 +73,9 @@ describe(packageJson.name, () => {
         settings: 'this is not valid json',
       })
       .expect(400)
-      .then(response => {
-        expect(response.body.message).to.equal('request.query.settings should be object');
-      })
+      .then((r: any) => {
+        const e = r.body;
+        expect(e.message).to.equal('request.query.settings should be object');
+      }),
   );
 });

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -68,7 +68,7 @@ describe(packageJson.name, () => {
     request(app)
       .get(`${app.basePath}/serialisable`)
       .query({
-        settings: 'this is not valid json'
+        settings: 'this is not valid json',
       })
       .expect(400)
       .then(response => {

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -71,8 +71,8 @@ describe(packageJson.name, () => {
         settings: 'this is not valid json',
       })
       .expect(400)
-      .then(response =>
-        expect(response.body.message).to.equal('request.query.settings should be object')
-      )
+      .then(response => {
+        expect(response.body.message).to.equal('request.query.settings should be object');
+      })
   );
 });


### PR DESCRIPTION
This updated test+parsing highlights when forced JSON.parsing is not appropriate, and should rely on validator to determine success.

Opened as an attempt to solve this issue: https://github.com/cdimascio/express-openapi-validator/issues/186

I tried my best to match existing code style, but wasn't sure if there was an official linter command/test. If so that has not been run but I am happy to tweak if necessary.