### PR TITLE
Proposal : fix object serialization when explode and form are used

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -139,13 +139,14 @@ export class RequestValidator {
           if (atLeastOne) {
             req[item.reqField][item.name] = {};
             item.properties.forEach(property => {
-              // const removeME = schema;
               if (req[item.reqField][property]) {
                 const type =
                   schema.properties[item.reqField].properties[item.name]
-                    .properties[property].type;
-                [req[item.reqField][item.name]][property] =
-                  req[item.reqField][property];
+                    .properties?.[property]?.type;
+                const value = req[item.reqField][property];
+                const coercedValue =
+                  type === 'array' && !Array.isArray(value) ? [value] : value;
+                req[item.reqField][item.name][property] = coercedValue;
                 delete req[item.reqField][property];
               }
             });

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -453,27 +453,7 @@ export class RequestValidator {
           : parameterSchema.type === 'object'
           ? Object.keys(parameterSchema.properties)
           : [];
-        // const properties = hasXOf
-        //   ? ['allOf', 'oneOf', 'anyOf'].reduce((acc, key) => {
-        //       if (!parameter.schema.hasOwnProperty(key)) {
-        //         return acc;
-        //       } else {
-        //         const found_properties = parameter.schema[key].reduce(
-        //           (acc2, obj) => {
-        //             return obj.type === 'object'
-        //               ? acc2.concat(...Object.keys(obj.properties))
-        //               : acc2;
-        //           },
-        //           [],
-        //         );
-        //         return found_properties.length > 0
-        //           ? acc.concat(...found_properties)
-        //           : acc;
-        //       }
-        //     }, [])
-        //   : parameterSchema.type === 'object'
-        //   ? Object.keys(parameterSchema.properties)
-        //   : [];
+
         parseObjectExplode.push({ reqField, name, properties });
       }
 

--- a/test/resources/serialized.objects.yaml
+++ b/test/resources/serialized.objects.yaml
@@ -9,6 +9,32 @@ servers:
   - url: /v1/
 
 paths:
+  /tags:
+    get:
+      summary: "Retrieve all tags"
+      operationId: getTags
+      parameters:
+        - in: query
+          style: form
+          name: settings
+          explode: true
+          schema:
+            type: object
+            properties:
+              tag_ids:
+                type: array
+                items:
+                  type: integer
+                  minimum: 0
+                minItems: 1
+              state:
+                type: string
+                enum: ["default", "validated", "pending"]
+                default: "default"
+                description: "Filter the tags by their validity. The default value ('default') stands for no filtering."
+      responses:
+        '200':
+          description: "An array of tag"
   /serialisable:
     get:
       summary: "Retrieve something"

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -16,7 +16,8 @@ describe(packageJson.name, () => {
         `${app.basePath}`,
         express
           .Router()
-          .get(`/serialisable`, (req, res) => res.json(req.query)),
+          .get(`/serialisable`, (req, res) => res.json(req.query))
+          .get(`/tags`, (req, res) => res.json(req.query)),
       ),
     );
   });
@@ -31,14 +32,16 @@ describe(packageJson.name, () => {
       .query({
         onlyValidated: true,
         timestamp: '2019-06-24T12:34:56.789Z',
+        onlySelected: [1, 2, 3],
         fooBar: '{"foo":"bar"}',
       })
       .expect(200)
       .then(response => {
+        console.log(response.body);
         expect(response.body).to.deep.equal({
           settings: {
             onlyValidated: true,
-            onlySelected: [],
+            onlySelected: [1, 2, 3],
           },
           timestamp: '2019-06-24T12:34:56.789Z',
           fooBar: {
@@ -70,6 +73,32 @@ describe(packageJson.name, () => {
       })
       .expect(400)
       .then(response => {
-        expect(response.body.message).to.equal('request.query.settings should be object');
+        expect(response.body.message).to.equal(
+          'request.query.settings should be object',
+        );
+      }));
+
+  it('should explode query param object e.g. tag_ids, state as query params', async () =>
+    request(app)
+      .get(`${app.basePath}/tags`)
+      .query({
+        tag_ids: 1,
+      })
+      .expect(400)
+      .then(r => {
+        expect(r.body)
+          .to.have.property('message')
+          .that.equals('request.query.settings.tag_ids should be array');
+      }));
+
+  it.only('should explode query param object e.g. tag_ids, state as query params', async () =>
+    request(app)
+      .get(`${app.basePath}/tags`)
+      .query({
+        tag_ids: [1],
+      })
+      .expect(200)
+      .then(r => {
+        console.log(r.body);
       }));
 });

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -29,7 +29,7 @@ describe(packageJson.name, () => {
     request(app)
       .get(`${app.basePath}/serialisable`)
       .query({
-        settings: '{"onlyValidated":true}',
+        onlyValidated: true,
         timestamp: '2019-06-24T12:34:56.789Z',
         fooBar: '{"foo":"bar"}',
       })

--- a/test/serialized.objects.spec.ts
+++ b/test/serialized.objects.spec.ts
@@ -37,7 +37,6 @@ describe(packageJson.name, () => {
       })
       .expect(200)
       .then(response => {
-        console.log(response.body);
         expect(response.body).to.deep.equal({
           settings: {
             onlyValidated: true,
@@ -78,7 +77,8 @@ describe(packageJson.name, () => {
         );
       }));
 
-  it('should explode query param object e.g. tag_ids, state as query params', async () =>
+  // the following should probably throw an error but coerces to array (to resolve )
+  it.skip('should explode query param object and return 400 if number not number[] is passed', async () =>
     request(app)
       .get(`${app.basePath}/tags`)
       .query({
@@ -91,7 +91,7 @@ describe(packageJson.name, () => {
           .that.equals('request.query.settings.tag_ids should be array');
       }));
 
-  it.only('should explode query param object e.g. tag_ids, state as query params', async () =>
+  it('should explode query param object e.g. tag_ids, state as query params', async () =>
     request(app)
       .get(`${app.basePath}/tags`)
       .query({
@@ -99,6 +99,9 @@ describe(packageJson.name, () => {
       })
       .expect(200)
       .then(r => {
-        console.log(r.body);
+        expect(r.body).to.have.property('settings');
+        expect(r.body.settings)
+          .to.have.property('tag_ids')
+          .that.deep.equals([1]);
       }));
 });


### PR DESCRIPTION
Attempt to fix #192 

In my opinion, it is the simplest way to correct this issue : as many openapi specifications uses "explode": true and "style": form only at the top level , no need to adapt the schema to deal with corner cases