### PR TITLE
handle allow empty value properly

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -161,7 +161,7 @@ export class RequestValidator {
         throw validationError(
           400,
           `.query.${q}`,
-          `Empty valued found for query parameter '${q}'`,
+          `Empty value found for query parameter '${q}'`,
         );
       }
     }

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -155,13 +155,13 @@ export class RequestValidator {
         throw validationError(
           400,
           `.query.${q}`,
-          `Unknown query parameter ${q}`,
+          `Unknown query parameter '${q}'`,
         );
       } else if (!allowedEmpty?.has(q) && (query[q] === '' || null)) {
         throw validationError(
           400,
           `.query.${q}`,
-          `query parameter ${q} has empty value`,
+          `Empty valued found for query parameter '${q}'`,
         );
       }
     }

--- a/src/middlewares/parsers/schema.parse.ts
+++ b/src/middlewares/parsers/schema.parse.ts
@@ -47,6 +47,12 @@ export class ParametersSchemaParser {
       }
 
       schemas[reqField].properties[name] = schema;
+      if (reqField === 'query' && parameter.allowEmptyValue) {
+        if (!schemas[reqField].allowEmptyValue) {
+          schemas[reqField].allowEmptyValue = new Set<string>();
+        }
+        schemas[reqField].allowEmptyValue.add(name);
+      }
       if (parameter.required) {
         if (!schemas[reqField].required) {
           schemas[reqField].required = [];

--- a/test/query.params.allow.unknown.spec.ts
+++ b/test/query.params.allow.unknown.spec.ts
@@ -32,6 +32,7 @@ describe(packageJson.name, () => {
     request(app)
       .get(`${app.basePath}/pets`)
       .query({
+        name: 'max',
         tags: 'one,two,three',
         limit: 10,
         breed: 'german_shepherd',
@@ -43,6 +44,7 @@ describe(packageJson.name, () => {
     request(app)
       .get(`${app.basePath}/pets`)
       .query({
+        name: 'max',
         tags: 'one,two,three',
         limit: 10,
         breed: 'german_shepherd',

--- a/test/query.params.spec.ts
+++ b/test/query.params.spec.ts
@@ -85,4 +85,9 @@ describe(packageJson.name, () => {
         owner_name: 'carmine',
       })
       .expect(200));
+
+      it("should succeed when query param 'name' has empty value and sets allowEmptyValue: true", async () =>
+      request(app)
+        .get(`${app.basePath}/pets?name=&tags=one&limit=10&breed=german_shepherd&owner_name=carmine`)
+        .expect(200));
 });

--- a/test/query.params.spec.ts
+++ b/test/query.params.spec.ts
@@ -67,7 +67,7 @@ describe(packageJson.name, () => {
       .then(r => {
         expect(r.body)
           .to.have.property('message')
-          .that.equals('query parameter breed has empty value');
+          .that.equals("Empty value found for query parameter 'breed'");
         expect(r.body.errors)
           .to.be.an('array')
           .with.length(1);

--- a/test/query.params.spec.ts
+++ b/test/query.params.spec.ts
@@ -29,6 +29,7 @@ describe(packageJson.name, () => {
     request(app)
       .get(`${app.basePath}/pets`)
       .query({
+        name: 'max',
         tags: 'one,two,three',
         limit: 10,
         breed: 'german_shepherd',
@@ -40,6 +41,7 @@ describe(packageJson.name, () => {
     request(app)
       .get(`${app.basePath}/pets`)
       .query({
+        name: 'max',
         tags: 'one,two,three',
         limit: 10,
         breed: 'german_shepherd',
@@ -50,4 +52,37 @@ describe(packageJson.name, () => {
       .then(r => {
         expect(r.body.errors).to.be.an('array');
       }));
+
+  it('should not allow empty query param value', async () =>
+    request(app)
+      .get(`${app.basePath}/pets`)
+      .query({
+        name: 'max',
+        tags: 'one,two,three',
+        limit: 10,
+        breed: '',
+        owner_name: 'carmine',
+      })
+      .expect(400)
+      .then(r => {
+        expect(r.body)
+          .to.have.property('message')
+          .that.equals('query parameter breed has empty value');
+        expect(r.body.errors)
+          .to.be.an('array')
+          .with.length(1);
+        expect(r.body.errors[0].path).to.equal('.query.breed');
+      }));
+
+  it('should allow empty query param value with allowEmptyValue: true', async () =>
+    request(app)
+      .get(`${app.basePath}/pets`)
+      .query({
+        name: '',
+        tags: 'one,two,three',
+        limit: 10,
+        breed: 'german_shepherd',
+        owner_name: 'carmine',
+      })
+      .expect(200));
 });

--- a/test/resources/query.params.yaml
+++ b/test/resources/query.params.yaml
@@ -35,6 +35,13 @@ paths:
       description: |
         Returns all pets from the system that the user has access tp
       parameters:
+        - name: name
+          in: query
+          description: name
+          required: true
+          schema:
+            type: string
+          allowEmptyValue: true
         - name: tags
           in: query
           description: tags to filter by

--- a/test/resources/query.params.yaml
+++ b/test/resources/query.params.yaml
@@ -35,13 +35,7 @@ paths:
       description: |
         Returns all pets from the system that the user has access tp
       parameters:
-        - name: name
-          in: query
-          description: name
-          required: true
-          schema:
-            type: string
-          allowEmptyValue: true
+        - $ref: '#/components/parameters/name'
         - name: tags
           in: query
           description: tags to filter by
@@ -80,6 +74,14 @@ paths:
                   $ref: '#/components/schemas/Pet'
 components:
   parameters:
+    name:
+      name: name
+      in: query
+      description: name
+      required: true
+      schema:
+        type: string
+      allowEmptyValue: true
     owner_name:
       name: owner_name
       in: query


### PR DESCRIPTION
Sets `allowEmptyValue` to false by default (as per spec)
Enables use of `allowEmptyValue: true` for query params (as per spec)