### PR TITLE
Changed validator.default to validators.default in openapi.response.validator.ts

### DIFF
--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -89,7 +89,7 @@ export class ResponseValidator {
       const statusXX = status.toString()[0] + 'XX';
       if (status in validators) validator = validators[status];
       else if (statusXX in validators) validator = validators[statusXX];
-      else if (validators.default) validator = validator.default;
+      else if (validators.default) validator = validators.default;
       else {
         throw validationError(
           500,


### PR DESCRIPTION
The wrong variable was used to access the validator which led to an error. Now the default validator can be accessed.