### PR TITLE
Features/allow full format validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,14 @@ Determines whether the validator should coerce value types to match the type def
 - `false` - no type coercion.
 - `"array"` - in addition to coercions between scalar types, coerce scalar data to an array with one element and vice versa (as required by the schema).
 
+### ▪️ validateFormats (optional)
+
+Specifies the strictness of validation of string formats.
+
+- `"fast"` (**default**) - only validate syntax, but not semantics. E.g. `2010-13-30T23:12:35Z` will pass validation eventhough it contains month 13.
+- `"full"` - validate both syntax and semantics. Illegal dates will not pass.
+- `false` - do not validate formats at all.
+
 ### ▪️ \$refParser.mode (optional)
 
 Determines how JSON schema references are resolved by the internal [json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser). Generally, the default mode, `bundle` is sufficient, however if you use [escape characters in \$refs](https://swagger.io/docs/specification/using-ref/), `dereference` is necessary.

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -62,6 +62,7 @@ export interface OpenApiValidatorOpts {
     mode: 'bundle' | 'dereference';
   };
   operationHandlers?: false | string;
+  formatValidation?: false | 'fast' | 'fail';
 }
 
 export namespace OpenAPIV3 {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -62,7 +62,7 @@ export interface OpenApiValidatorOpts {
     mode: 'bundle' | 'dereference';
   };
   operationHandlers?: false | string;
-  formatValidation?: false | 'fast' | 'full';
+  validateFormats?: false | 'fast' | 'full';
 }
 
 export namespace OpenAPIV3 {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -62,7 +62,7 @@ export interface OpenApiValidatorOpts {
     mode: 'bundle' | 'dereference';
   };
   operationHandlers?: false | string;
-  formatValidation?: false | 'fast' | 'fail';
+  formatValidation?: false | 'fast' | 'full';
 }
 
 export namespace OpenAPIV3 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export class OpenApiValidator {
     if (options.fileUploader == null) options.fileUploader = {};
     if (options.$refParser == null) options.$refParser = { mode: 'bundle' };
     if (options.operationHandlers == null) options.operationHandlers = false;
-    if (options.formatValidation == null) options.formatValidation = 'fast';
+    if (options.validateFormats == null) options.validateFormats = 'fast';
 
     if (options.validateResponses === true) {
       options.validateResponses = {
@@ -175,7 +175,7 @@ export class OpenApiValidator {
     app: Application | Router,
     context: OpenApiContext,
   ): void {
-    const { coerceTypes, unknownFormats, validateRequests, formatValidation } = this.options;
+    const { coerceTypes, unknownFormats, validateRequests, validateFormats } = this.options;
     const { allowUnknownQueryParameters } = <ValidateRequestOpts>(
       validateRequests
     );
@@ -186,7 +186,7 @@ export class OpenApiValidator {
       useDefaults: true,
       unknownFormats,
       allowUnknownQueryParameters,
-      format: formatValidation
+      format: validateFormats
     });
     const requestValidationHandler: OpenApiRequestHandler = (req, res, next) =>
       requestValidator.validate(req, res, next);
@@ -198,7 +198,7 @@ export class OpenApiValidator {
     app: Application | Router,
     context: OpenApiContext,
   ): void {
-    const { coerceTypes, unknownFormats, validateResponses, formatValidation } = this.options;
+    const { coerceTypes, unknownFormats, validateResponses, validateFormats } = this.options;
     const { removeAdditional } = <ValidateResponseOpts>validateResponses;
 
     const responseValidator = new middlewares.ResponseValidator(
@@ -208,7 +208,7 @@ export class OpenApiValidator {
         coerceTypes,
         removeAdditional,
         unknownFormats,
-        format: formatValidation
+        format: validateFormats
       },
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export class OpenApiValidator {
     if (options.fileUploader == null) options.fileUploader = {};
     if (options.$refParser == null) options.$refParser = { mode: 'bundle' };
     if (options.operationHandlers == null) options.operationHandlers = false;
+    if (options.formatValidation == null) options.formatValidation = 'fast';
 
     if (options.validateResponses === true) {
       options.validateResponses = {
@@ -174,7 +175,7 @@ export class OpenApiValidator {
     app: Application | Router,
     context: OpenApiContext,
   ): void {
-    const { coerceTypes, unknownFormats, validateRequests } = this.options;
+    const { coerceTypes, unknownFormats, validateRequests, formatValidation } = this.options;
     const { allowUnknownQueryParameters } = <ValidateRequestOpts>(
       validateRequests
     );
@@ -185,6 +186,7 @@ export class OpenApiValidator {
       useDefaults: true,
       unknownFormats,
       allowUnknownQueryParameters,
+      format: formatValidation
     });
     const requestValidationHandler: OpenApiRequestHandler = (req, res, next) =>
       requestValidator.validate(req, res, next);
@@ -196,7 +198,7 @@ export class OpenApiValidator {
     app: Application | Router,
     context: OpenApiContext,
   ): void {
-    const { coerceTypes, unknownFormats, validateResponses } = this.options;
+    const { coerceTypes, unknownFormats, validateResponses, formatValidation } = this.options;
     const { removeAdditional } = <ValidateResponseOpts>validateResponses;
 
     const responseValidator = new middlewares.ResponseValidator(
@@ -206,6 +208,7 @@ export class OpenApiValidator {
         coerceTypes,
         removeAdditional,
         unknownFormats,
+        format: formatValidation
       },
     );
 

--- a/test/datetime.validation.spec.ts
+++ b/test/datetime.validation.spec.ts
@@ -6,14 +6,14 @@ import {createApp} from './common/app';
 describe("datetime.validation", () => {
   let app = null;
 
-  async function setupServer(formatValidation?: false | "full" | "fast") {
+  async function setupServer(validateFormats?: false | "full" | "fast") {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'datetime.validation.yaml');
     app = await createApp(
       {
         apiSpec,
         validateResponses: true,
-        formatValidation
+        validateFormats
       },
       3005,
       app => {

--- a/test/datetime.validation.spec.ts
+++ b/test/datetime.validation.spec.ts
@@ -1,0 +1,101 @@
+import * as path from 'path';
+import {expect} from 'chai';
+import * as request from 'supertest';
+import {createApp} from './common/app';
+
+describe("datetime.validation", () => {
+  let app = null;
+
+  async function setupServer(formatValidation?: false | "full" | "fast") {
+    // Set up the express app
+    const apiSpec = path.join('test', 'resources', 'datetime.validation.yaml');
+    app = await createApp(
+      {
+        apiSpec,
+        validateResponses: true,
+        formatValidation
+      },
+      3005,
+      app => {
+        // Define new coercion routes
+        app.post(`${app.basePath}/date-time-validation`, (req, res) => {
+          res.json(req.body);
+        });
+      },
+      true,
+    );
+  }
+
+  beforeEach(() => {
+    app = null;
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await new Promise(resolve => app.server.close(resolve));
+    }
+  });
+
+
+  it('should return 200 if testDateTimeProperty is provided with invalid, but correctly formatted date time and default validation is enabled (past compatibility)', async () => {
+    await setupServer();
+    await request(app)
+      .post(`${app.basePath}/date-time-validation`)
+      .send({
+        testDateTimeProperty: '2000-13-03T12:13:14Z',
+      })
+      .expect(200)
+      .then(r => {
+        const {body} = r;
+        expect(body).to.have.property('testDateTimeProperty');
+      });
+  });
+
+  it('should return 400 if testDateTimeProperty is provided with incorrectly formatted date time and default validation enabled (past compatibility)', async () => {
+    await setupServer();
+    await request(app)
+      .post(`${app.basePath}/date-time-validation`)
+      .send({
+        testDateTimeProperty: 'wrong',
+      })
+      .expect(400);
+  });
+
+  it('should return 200 if testDateTimeProperty is provided with incorrectly formatted date time and format validation disabled', async () => {
+    await setupServer(false);
+    await request(app)
+      .post(`${app.basePath}/date-time-validation`)
+      .send({
+        testDateTimeProperty: 'blah-blah',
+      })
+      .expect(200)
+      .then(r => {
+        const {body} = r;
+        expect(body).to.have.property('testDateTimeProperty');
+      });
+  });
+
+  it('should return 200 if testDateTimeProperty is provided with valid date time and full validation enabled', async () => {
+    await setupServer("full");
+    await request(app)
+      .post(`${app.basePath}/date-time-validation`)
+      .send({
+        testDateTimeProperty: '2000-02-03T12:13:14Z',
+      })
+      .expect(200)
+      .then(r => {
+        const {body} = r;
+        expect(body).to.have.property('testDateTimeProperty');
+      });
+  });
+
+  it('should return 400 if testDateTimeProperty is provided with invalid date time and full validation enabled', async () => {
+    await setupServer("full");
+    await request(app)
+      .post(`${app.basePath}/date-time-validation`)
+      .send({
+        testDateTimeProperty: '2000-13-03T12:13:14Z',
+      })
+      .expect(400);
+  });
+});

--- a/test/resources/datetime.validation.yaml
+++ b/test/resources/datetime.validation.yaml
@@ -1,0 +1,39 @@
+openapi: '3.0.2'
+info:
+  version: 1.0.0
+  title: date-time validation test
+  description: date-time validation test
+
+servers:
+  - url: /v1/
+
+paths:
+  /date-time-validation:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Test'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Test'
+        '400':
+          description: Bad Request
+
+components:
+  schemas:
+    Test:
+      type: object
+      additionalProperties: false
+      properties:
+        testDateTimeProperty:
+          type: string
+          format: date-time
+      required:
+        - testDateTimeProperty


### PR DESCRIPTION
Allow to specify `format` option to AJP to be able to validate `date-time` format fully. By default only the syntax is checked. With `formatValidation='full' AJP also validates, that the date actually exists.
Default behaviour is compatible with past version.
