### PR TITLE
Update api.yaml for /pets route. Both x-eov-operationId and operation…

### DIFF
--- a/examples/3-eov-operations/api.yaml
+++ b/examples/3-eov-operations/api.yaml
@@ -14,7 +14,7 @@ paths:
     get:
       description: |
         ping then pong!
-      # use operationId, (x-eov-operation-id is optional. it can be used in place of operationId or to override it)
+      # operationId is used in /ping path (x-eov-operation-id is optional). x-eov-operation-id can be used in place of operationId. If both x-eov-operation-id and operationId are present, x-eov-operation-id will override operationId.
       operationId: ping 
       x-eov-operation-handler: routes/ping 
       responses:
@@ -35,7 +35,7 @@ paths:
     get:
       description: |
         Returns all pets
-      operationId: findPets
+      # x-eov-operation-id is specified as well as operationId. This allows for backwards compatibility with code generator tools that rely on operationId in the OpenAPI spec.
       x-eov-operation-id: pets#list
       x-eov-operation-handler: routes/pets
       parameters:


### PR DESCRIPTION
The route /pets was updated and exports, 'pets#list'. The 'x-eov-operation-id' param has this updated value, however 'operationId' has 'findPets' which cannot be found in the pets route. Further, only the 'x-eov-operation-id' is necessary as it overrides 'operationId' as noted in comment on line 17: https://github.com/cdimascio/express-openapi-validator/blob/master/examples/3-eov-operations/api.yaml#L17. 

**_Summary_**: this line can be removed 
https://github.com/cdimascio/express-openapi-validator/blob/2f0c206abb0490909bf0ea48d5cdde204544201c/examples/3-eov-operations/api.yaml#L38