### PR TITLE
Example-1 fix for creation endpoint

### DIFF
--- a/examples/1-standard/app.js
+++ b/examples/1-standard/app.js
@@ -39,7 +39,7 @@ new OpenApiValidator({
     });
 
     app.post('/v1/pets', function(req, res, next) {
-      res.json(pets.add({ ...req.body }));
+      res.json(pets.create({ ...req.body }));
     });
 
     app.get('/v1/pets/:id', function(req, res, next) {

--- a/examples/1-standard/package-lock.json
+++ b/examples/1-standard/package-lock.json
@@ -403,9 +403,9 @@
       "requires": {
         "ajv": "^6.12.2",
         "content-type": "^1.0.4",
-        "deasync": "^0.1.19",
+        "deasync": "^0.1.20",
         "js-yaml": "^3.14.0",
-        "json-schema-ref-parser": "^8.0.0",
+        "json-schema-ref-parser": "^9.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0",
         "lodash.zipobject": "^4.1.3",


### PR DESCRIPTION
Example-1 was broken using the post functionality on `/v1/pets`. This fixes that issue.