### PR TITLE
unused deps cookie-parser in examples and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ See the complete [source code](https://github.com/cdimascio/express-openapi-vali
 ```javascript
 const express = require('express');
 const path = require('path');
-const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const logger = require('morgan');
 const http = require('http');
@@ -101,8 +100,6 @@ app.use(bodyParser.text());
 app.use(bodyParser.urlencoded({ extended: false }));
 
 app.use(logger('dev'));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
 
 // 3. (optionally) Serve the OpenAPI spec
 const spec = path.join(__dirname, 'example.yaml');
@@ -215,7 +212,6 @@ Below are some code snippets:
 ```javascript
 const express = require('express');
 const path = require('path');
-const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const logger = require('morgan');
 const http = require('http');
@@ -231,8 +227,6 @@ app.use(bodyParser.text());
 app.use(bodyParser.json());
 
 app.use(logger('dev'));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/spec', express.static(apiSpec));
 
@@ -954,7 +948,6 @@ async function main() {
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(bodyParser.text());
   app.use(bodyParser.json());
-  app.use(express.static(path.join(__dirname, 'public')));
 
   const versions = [1, 2];
 

--- a/examples/1-standard/app.js
+++ b/examples/1-standard/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const path = require('path');
-const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const logger = require('morgan');
 const http = require('http');
@@ -17,8 +16,6 @@ app.use(bodyParser.text());
 app.use(bodyParser.json());
 
 app.use(logger('dev'));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/spec', express.static(apiSpec));
 

--- a/examples/1-standard/package-lock.json
+++ b/examples/1-standard/package-lock.json
@@ -298,25 +298,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-    },
-    "cookie-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
-      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
-      "requires": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6"
-      }
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -401,7 +382,7 @@
     "express-openapi-validator": {
       "version": "file:../..",
       "requires": {
-        "ajv": "^6.12.2",
+        "ajv": "^6.12.3",
         "content-type": "^1.0.4",
         "deasync": "^0.1.20",
         "js-yaml": "^3.14.0",
@@ -416,11 +397,11 @@
       },
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-+tOjAEtnsa0/0lAEpR9zDBkVhhszU+J23egkniV4zCYWVW7yd2Rjxr+NSYz6Zo2VbNdJiuoN22rg6qGz5OKGDQ==",
           "requires": {
-            "@jsdevtools/ono": "^7.1.0",
+            "@jsdevtools/ono": "^7.1.3",
             "call-me-maybe": "^1.0.1",
             "js-yaml": "^3.13.1"
           }
@@ -631,9 +612,9 @@
           "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
         },
         "@jsdevtools/ono": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.1.tgz",
-          "integrity": "sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A=="
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+          "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
         },
         "@types/ajv": {
           "version": "1.0.0",
@@ -798,9 +779,9 @@
           }
         },
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1375,9 +1356,9 @@
           }
         },
         "deasync": {
-          "version": "0.1.19",
-          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
-          "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
+          "version": "0.1.20",
+          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
+          "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -1655,9 +1636,9 @@
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -2502,11 +2483,11 @@
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-2P4icmNkZLrBr6oa5gSZaDSol/oaBHYkoP/8dsw63E54NnHGRhhiFuy9yFoxPuSm+uHKmeGxAAWMDF16SCHhcQ==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-bPp/VXAGaa4fk5C9qNZfsv2y4WPr2LV1jrQepvgRC3+RYQohsFYF+W7gI3ipXSS2yEtE/itmB9O813xRv7qdHw==",
           "requires": {
-            "@apidevtools/json-schema-ref-parser": "8.0.0"
+            "@apidevtools/json-schema-ref-parser": "9.0.5"
           }
         },
         "json-schema-traverse": {
@@ -2802,9 +2783,9 @@
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-addon-api": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-          "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+          "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
           "optional": true
         },
         "node-environment-flags": {

--- a/examples/1-standard/package.json
+++ b/examples/1-standard/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "cookie-parser": "^1.4.5",
     "express-openapi-validator": "file:../../",
     "morgan": "^1.10.0"
   },

--- a/examples/2-standard-multiple-api-specs/app.js
+++ b/examples/2-standard-multiple-api-specs/app.js
@@ -9,7 +9,6 @@ async function main() {
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(bodyParser.text());
   app.use(bodyParser.json());
-  app.use(express.static(path.join(__dirname, 'public')));
 
   const versions = [1, 2];
 

--- a/examples/2-standard-multiple-api-specs/package-lock.json
+++ b/examples/2-standard-multiple-api-specs/package-lock.json
@@ -298,25 +298,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-    },
-    "cookie-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
-      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
-      "requires": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6"
-      }
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -401,11 +382,11 @@
     "express-openapi-validator": {
       "version": "file:../..",
       "requires": {
-        "ajv": "^6.12.2",
+        "ajv": "^6.12.3",
         "content-type": "^1.0.4",
-        "deasync": "^0.1.19",
+        "deasync": "^0.1.20",
         "js-yaml": "^3.14.0",
-        "json-schema-ref-parser": "^8.0.0",
+        "json-schema-ref-parser": "^9.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0",
         "lodash.zipobject": "^4.1.3",
@@ -416,11 +397,11 @@
       },
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-+tOjAEtnsa0/0lAEpR9zDBkVhhszU+J23egkniV4zCYWVW7yd2Rjxr+NSYz6Zo2VbNdJiuoN22rg6qGz5OKGDQ==",
           "requires": {
-            "@jsdevtools/ono": "^7.1.0",
+            "@jsdevtools/ono": "^7.1.3",
             "call-me-maybe": "^1.0.1",
             "js-yaml": "^3.13.1"
           }
@@ -631,9 +612,9 @@
           "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
         },
         "@jsdevtools/ono": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.1.tgz",
-          "integrity": "sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A=="
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+          "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
         },
         "@types/ajv": {
           "version": "1.0.0",
@@ -798,9 +779,9 @@
           }
         },
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1375,9 +1356,9 @@
           }
         },
         "deasync": {
-          "version": "0.1.19",
-          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
-          "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
+          "version": "0.1.20",
+          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
+          "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -1655,9 +1636,9 @@
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -2502,11 +2483,11 @@
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-2P4icmNkZLrBr6oa5gSZaDSol/oaBHYkoP/8dsw63E54NnHGRhhiFuy9yFoxPuSm+uHKmeGxAAWMDF16SCHhcQ==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-bPp/VXAGaa4fk5C9qNZfsv2y4WPr2LV1jrQepvgRC3+RYQohsFYF+W7gI3ipXSS2yEtE/itmB9O813xRv7qdHw==",
           "requires": {
-            "@apidevtools/json-schema-ref-parser": "8.0.0"
+            "@apidevtools/json-schema-ref-parser": "9.0.5"
           }
         },
         "json-schema-traverse": {
@@ -2701,7 +2682,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2801,9 +2783,9 @@
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-addon-api": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-          "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+          "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
           "optional": true
         },
         "node-environment-flags": {

--- a/examples/2-standard-multiple-api-specs/package.json
+++ b/examples/2-standard-multiple-api-specs/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "cookie-parser": "^1.4.5",
     "express-openapi-validator": "file:../../",
     "morgan": "^1.10.0"
   },

--- a/examples/3-eov-operations/app.js
+++ b/examples/3-eov-operations/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const path = require('path');
-const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const logger = require('morgan');
 const http = require('http');
@@ -16,8 +15,6 @@ app.use(bodyParser.text());
 app.use(bodyParser.json());
 
 app.use(logger('dev'));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/spec', express.static(apiSpec));
 

--- a/examples/3-eov-operations/package-lock.json
+++ b/examples/3-eov-operations/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "7": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/7/-/7-0.0.1.tgz",
-      "integrity": "sha1-npaOPGkAISvVjW+OW30P/Auyj0w="
-    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -303,25 +298,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-    },
-    "cookie-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
-      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
-      "requires": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6"
-      }
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -406,11 +382,11 @@
     "express-openapi-validator": {
       "version": "file:../..",
       "requires": {
-        "ajv": "^6.12.2",
+        "ajv": "^6.12.3",
         "content-type": "^1.0.4",
-        "deasync": "^0.1.19",
+        "deasync": "^0.1.20",
         "js-yaml": "^3.14.0",
-        "json-schema-ref-parser": "^8.0.0",
+        "json-schema-ref-parser": "^9.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0",
         "lodash.zipobject": "^4.1.3",
@@ -421,11 +397,11 @@
       },
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-+tOjAEtnsa0/0lAEpR9zDBkVhhszU+J23egkniV4zCYWVW7yd2Rjxr+NSYz6Zo2VbNdJiuoN22rg6qGz5OKGDQ==",
           "requires": {
-            "@jsdevtools/ono": "^7.1.0",
+            "@jsdevtools/ono": "^7.1.3",
             "call-me-maybe": "^1.0.1",
             "js-yaml": "^3.13.1"
           }
@@ -636,9 +612,9 @@
           "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
         },
         "@jsdevtools/ono": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.1.tgz",
-          "integrity": "sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A=="
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+          "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
         },
         "@types/ajv": {
           "version": "1.0.0",
@@ -803,9 +779,9 @@
           }
         },
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1388,9 +1364,9 @@
           }
         },
         "deasync": {
-          "version": "0.1.19",
-          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
-          "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
+          "version": "0.1.20",
+          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
+          "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -1668,9 +1644,9 @@
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -2515,11 +2491,11 @@
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-2P4icmNkZLrBr6oa5gSZaDSol/oaBHYkoP/8dsw63E54NnHGRhhiFuy9yFoxPuSm+uHKmeGxAAWMDF16SCHhcQ==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-bPp/VXAGaa4fk5C9qNZfsv2y4WPr2LV1jrQepvgRC3+RYQohsFYF+W7gI3ipXSS2yEtE/itmB9O813xRv7qdHw==",
           "requires": {
-            "@apidevtools/json-schema-ref-parser": "8.0.0"
+            "@apidevtools/json-schema-ref-parser": "9.0.5"
           }
         },
         "json-schema-traverse": {
@@ -2724,7 +2700,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2824,9 +2801,9 @@
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-addon-api": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-          "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+          "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
           "optional": true
         },
         "node-environment-flags": {

--- a/examples/3-eov-operations/package.json
+++ b/examples/3-eov-operations/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "cookie-parser": "^1.4.5",
     "express-openapi-validator": "file:../../",
     "morgan": "^1.10.0"
   },

--- a/examples/4-eov-operations-babel/package-lock.json
+++ b/examples/4-eov-operations-babel/package-lock.json
@@ -1705,25 +1705,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-    },
-    "cookie-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
-      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
-      "requires": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6"
-      }
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -1993,11 +1974,11 @@
     "express-openapi-validator": {
       "version": "file:../..",
       "requires": {
-        "ajv": "^6.12.2",
+        "ajv": "^6.12.3",
         "content-type": "^1.0.4",
-        "deasync": "^0.1.19",
+        "deasync": "^0.1.20",
         "js-yaml": "^3.14.0",
-        "json-schema-ref-parser": "^8.0.0",
+        "json-schema-ref-parser": "^9.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0",
         "lodash.zipobject": "^4.1.3",
@@ -2008,24 +1989,24 @@
       },
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-+tOjAEtnsa0/0lAEpR9zDBkVhhszU+J23egkniV4zCYWVW7yd2Rjxr+NSYz6Zo2VbNdJiuoN22rg6qGz5OKGDQ==",
           "requires": {
-            "@jsdevtools/ono": "^7.1.0",
+            "@jsdevtools/ono": "^7.1.3",
             "call-me-maybe": "^1.0.1",
             "js-yaml": "^3.13.1"
           }
         },
         "@jsdevtools/ono": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.1.tgz",
-          "integrity": "sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A=="
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+          "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
         },
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -2125,9 +2106,9 @@
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "deasync": {
-          "version": "0.1.19",
-          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
-          "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
+          "version": "0.1.20",
+          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
+          "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -2154,9 +2135,9 @@
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -2189,11 +2170,11 @@
           }
         },
         "json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-2P4icmNkZLrBr6oa5gSZaDSol/oaBHYkoP/8dsw63E54NnHGRhhiFuy9yFoxPuSm+uHKmeGxAAWMDF16SCHhcQ==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-bPp/VXAGaa4fk5C9qNZfsv2y4WPr2LV1jrQepvgRC3+RYQohsFYF+W7gI3ipXSS2yEtE/itmB9O813xRv7qdHw==",
           "requires": {
-            "@apidevtools/json-schema-ref-parser": "8.0.0"
+            "@apidevtools/json-schema-ref-parser": "9.0.5"
           }
         },
         "json-schema-traverse": {
@@ -2263,9 +2244,9 @@
           }
         },
         "node-addon-api": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-          "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+          "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
           "optional": true
         },
         "object-assign": {

--- a/examples/4-eov-operations-babel/package.json
+++ b/examples/4-eov-operations-babel/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "cookie-parser": "^1.4.5",
     "express-openapi-validator": "file:../../",
     "morgan": "^1.10.0"
   },

--- a/examples/4-eov-operations-babel/src/app.js
+++ b/examples/4-eov-operations-babel/src/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const path = require('path');
-const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const logger = require('morgan');
 const http = require('http');
@@ -16,8 +15,6 @@ app.use(bodyParser.text());
 app.use(bodyParser.json());
 
 app.use(logger('dev'));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/spec', express.static(apiSpec));
 

--- a/examples/5-custom-operation-resolver/app.js
+++ b/examples/5-custom-operation-resolver/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const path = require('path');
-const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const logger = require('morgan');
 const http = require('http');
@@ -16,8 +15,6 @@ app.use(bodyParser.text());
 app.use(bodyParser.json());
 
 app.use(logger('dev'));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/spec', express.static(apiSpec));
 

--- a/examples/5-custom-operation-resolver/package-lock.json
+++ b/examples/5-custom-operation-resolver/package-lock.json
@@ -298,25 +298,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-    },
-    "cookie-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
-      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
-      "requires": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6"
-      }
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -401,11 +382,11 @@
     "express-openapi-validator": {
       "version": "file:../..",
       "requires": {
-        "ajv": "^6.12.2",
+        "ajv": "^6.12.3",
         "content-type": "^1.0.4",
-        "deasync": "^0.1.19",
+        "deasync": "^0.1.20",
         "js-yaml": "^3.14.0",
-        "json-schema-ref-parser": "^8.0.0",
+        "json-schema-ref-parser": "^9.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0",
         "lodash.zipobject": "^4.1.3",
@@ -416,11 +397,11 @@
       },
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-+tOjAEtnsa0/0lAEpR9zDBkVhhszU+J23egkniV4zCYWVW7yd2Rjxr+NSYz6Zo2VbNdJiuoN22rg6qGz5OKGDQ==",
           "requires": {
-            "@jsdevtools/ono": "^7.1.0",
+            "@jsdevtools/ono": "^7.1.3",
             "call-me-maybe": "^1.0.1",
             "js-yaml": "^3.13.1"
           }
@@ -631,9 +612,9 @@
           "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
         },
         "@jsdevtools/ono": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.1.tgz",
-          "integrity": "sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A=="
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+          "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
         },
         "@types/ajv": {
           "version": "1.0.0",
@@ -798,9 +779,9 @@
           }
         },
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1383,9 +1364,9 @@
           }
         },
         "deasync": {
-          "version": "0.1.19",
-          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
-          "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
+          "version": "0.1.20",
+          "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.20.tgz",
+          "integrity": "sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==",
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -1663,9 +1644,9 @@
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -2510,11 +2491,11 @@
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-2P4icmNkZLrBr6oa5gSZaDSol/oaBHYkoP/8dsw63E54NnHGRhhiFuy9yFoxPuSm+uHKmeGxAAWMDF16SCHhcQ==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
+          "integrity": "sha512-bPp/VXAGaa4fk5C9qNZfsv2y4WPr2LV1jrQepvgRC3+RYQohsFYF+W7gI3ipXSS2yEtE/itmB9O813xRv7qdHw==",
           "requires": {
-            "@apidevtools/json-schema-ref-parser": "8.0.0"
+            "@apidevtools/json-schema-ref-parser": "9.0.5"
           }
         },
         "json-schema-traverse": {
@@ -2820,9 +2801,9 @@
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-addon-api": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-          "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+          "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
           "optional": true
         },
         "node-environment-flags": {

--- a/examples/5-custom-operation-resolver/package.json
+++ b/examples/5-custom-operation-resolver/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "cookie-parser": "^1.4.5",
     "express-openapi-validator": "file:../../",
     "morgan": "^1.10.0"
   },


### PR DESCRIPTION
- Removed unused cookie-parser in package.json as well as in the sample code itself 
- Removed the non-existing `public` path exposed as static by the sample apps
- Updated the README to reflect these small changes