### PR TITLE
Introduce apiDoc as a param for operation resolver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -276,7 +276,7 @@ export class OpenApiValidator {
        */
       if (this.isOperationHandlerOptions(this.options.operationHandlers)) {
         const { basePath, resolver } = this.options.operationHandlers;
-        app[method.toLowerCase()](expressRoute, resolver(basePath, route));
+        app[method.toLowerCase()](expressRoute, resolver(basePath, route, context.apiDoc));
       }
     }
   }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,8 +1,9 @@
 import * as path from 'path';
 import { RequestHandler } from "express";
 import { RouteMetadata } from "./framework/openapi.spec.loader";
+import { OpenAPIV3 } from "./framework/types"
 
-export function defaultResolver(handlersPath: string, route: RouteMetadata): RequestHandler {
+export function defaultResolver(handlersPath: string, route: RouteMetadata, apiDoc: OpenAPIV3.Document): RequestHandler {
   const tmpModules = {};
   const { expressRoute, method, schema } = route;
   const oId = schema['x-eov-operation-id'] || schema['operationId'];
@@ -39,7 +40,7 @@ export function defaultResolver(handlersPath: string, route: RouteMetadata): Req
   }
 }
 
-export function modulePathResolver(handlersPath: string, route: RouteMetadata): RequestHandler {
+export function modulePathResolver(handlersPath: string, route: RouteMetadata, apiDoc: OpenAPIV3.Document): RequestHandler {
   const [controller, method] = route.schema['operationId'].split('.')
 
   const modulePath = path.join(handlersPath, controller);


### PR DESCRIPTION
## Background

I've been working on an operation resolver where on startup and running in `development` mode, if an operation cannot be resolved insted if available, an example response or schema is returned. This is done with the aim to both promote an API design first process and the usage of examples in the API. This ideally would introduce a mock server element by default to a service using this middleware.

## The Issue

I initially made use of the `refParser.mode: deference` option to allow me access to all API elements. This worked well until a point where I introduced circular refs (which at this time I require). Next I thought about using the `bundle` option and handle the dereferencing  myself within the resolver. I'm unable to do this as while I have the refs, I don't have the the full document to fetch the elements from.

This is an issue when attempting to use `example | examples` defined by $refs with the the `bundle` option - regardless of circular refs.

## Solution

By adding a 3rd `apiDoc` parameter, I can attempt to handle the dereferencing myself so that I might be able to server example responses.

## WIP

 - Tests to verify behaviour
 - Complete resolver that might make use of this