### PR TITLE
Enable default styles for array parameter delimiters

### DIFF
--- a/test/resources/query.params.yaml
+++ b/test/resources/query.params.yaml
@@ -85,7 +85,6 @@ paths:
           in: query
           description: tags to filter by
           required: false
-          style: form
           schema:
             type: array
             items:


### PR DESCRIPTION
Styles are not required in OpenAPI, ensure that we use the default
delimiting styles when none is provided.