### PR TITLE
fix #380: allow any string to be servers variables

### DIFF
--- a/src/framework/base.path.ts
+++ b/src/framework/base.path.ts
@@ -20,7 +20,7 @@ export class BasePath {
     let urlPath = this.findUrlPath(server.url);
     if (/{\w+}/.test(urlPath)) {
       // has variable that we need to check out
-      urlPath = urlPath.replace(/{(\w+)}/g, (substring, p1) => `:${p1}`);
+      urlPath = urlPath.replace(/{(\w+)}/g, (substring, p1) => `:${p1}(.*)`);
     }
     this.path = urlPath;
     for (const variable in server.variables) {


### PR DESCRIPTION
According to the OpenAPI 3.0 specification, we should be able to use any variables in servers. More comments can be found in this issue: https://github.com/cdimascio/express-openapi-validator/issues/380

This change is based on the latest documentation of [path-to-regexp](https://github.com/pillarjs/path-to-regexp) that we can specify the pattern of each path parameters
