### PR TITLE
Allow JSON Response to Return Boolean `false` Value

### DIFF
--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -54,8 +54,8 @@ export class ResponseValidator {
         const accepts: [string] = contentType
           ? [contentType]
           : accept
-          ? accept.split(',').map((h) => h.trim())
-          : [];
+            ? accept.split(',').map((h) => h.trim())
+            : [];
 
         return this._validate({
           validators,
@@ -136,7 +136,7 @@ export class ResponseValidator {
       return;
     }
 
-    if (!body) {
+    if (body === undefined || body === null) {
       throw new InternalServerError({
         path: '.response',
         message: 'response body required.',

--- a/test/resources/response.validation.yaml
+++ b/test/resources/response.validation.yaml
@@ -34,6 +34,22 @@ paths:
       responses:
         '200':
           description: empty
+  /boolean:
+    description: get boolean responses
+    get:
+      operationId: boolean
+      parameters:
+        - name: value
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: boolean
+          content:
+            application/json:
+              schema:
+                type: boolean
   /object:
     description: endpoints for pets
     summary: endpoints for pets

--- a/test/response.validation.spec.ts
+++ b/test/response.validation.spec.ts
@@ -25,6 +25,9 @@ describe(packageJson.name, () => {
         app.get(`${app.basePath}/empty_response`, (req, res) => {
           return res.end();
         });
+        app.get(`${app.basePath}/boolean`, (req, res) => {
+          return res.json(req.query.value);
+        })
         app.get(`${app.basePath}/object`, (req, res) => {
           return res.json([
             { id: 1, name: 'name', tag: 'tag', bought_at: null },
@@ -196,5 +199,21 @@ describe(packageJson.name, () => {
       .expect(200)
       .then((r: any) => {
         expect(r.body).is.an('array').with.length(3);
+      }));
+
+  it('should be able to return `true` as the response body', async () =>
+    request(app)
+      .get(`${app.basePath}/boolean?value=true`)
+      .expect(200)
+      .then((r: any) => {
+        expect(r.body).to.equal(true);
+      }));
+
+  it('should be able to return `false` as the response body', async () =>
+    request(app)
+      .get(`${app.basePath}/boolean?value=false`)
+      .expect(200)
+      .then((r: any) => {
+        expect(r.body).to.equal(false);
       }));
 });


### PR DESCRIPTION
Currently the implementation will fail to validate responses that return a simple JSON boolean value in the case where the value returned is `false`.

This is due to a check in the response validator to see if the body of a response exists and returns a `500` response if it does not, which currently uses a shorthand check for the existence of the response body. As a result if the response body is set to a simple `false` value it is treated as if the body does not exist.