### PR TITLE
fix: optional requestBody handling / add tests

### DIFF
--- a/src/middlewares/parsers/body.parse.ts
+++ b/src/middlewares/parsers/body.parse.ts
@@ -68,11 +68,15 @@ export class BodySchemaParser {
       }
 
       if (!content) {
-        const msg =
-          contentType.contentType === 'not_provided'
-            ? 'media type not specified'
-            : `unsupported media type ${contentType.contentType}`;
-        throw new UnsupportedMediaType({ path: path, message: msg });
+        if (contentType.contentType !== undefined) {
+          const msg =
+            contentType.contentType === 'not_provided'
+              ? 'media type not specified'
+              : `unsupported media type ${contentType.contentType}`;
+          throw new UnsupportedMediaType({ path: path, message: msg });
+        } else {
+          content = {};
+        }
       }
 
       const schema = this.cleanseContentSchema(content);

--- a/test/optional-request-body.spec.ts
+++ b/test/optional-request-body.spec.ts
@@ -1,0 +1,40 @@
+import * as path from 'path';
+import * as express from 'express';
+import * as request from 'supertest';
+import { createApp } from './common/app';
+import * as packageJson from '../package.json';
+
+describe(packageJson.name, () => {
+  let app = null;
+
+  before(async () => {
+    // Set up the express app
+    const apiSpec = path.join(__dirname, 'optional-request-body.yaml');
+    app = await createApp({ apiSpec }, 3005, (app) =>
+      app.use(
+        express.Router().post(`/documents`, (req, res) =>
+          res.status(201).json({
+            id: 123,
+            name: req.body ? req.body.name : ''
+          }),
+        ),
+      ),
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('create document should return 201', async () =>
+    request(app)
+      .post(`/documents`)
+      .expect(201));
+
+  it('return 415', async () =>
+    request(app)
+      .post(`/documents`)
+      .set('Content-Type', 'image/png')
+      .send()
+      .expect(415));
+});

--- a/test/optional-request-body.yaml
+++ b/test/optional-request-body.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.2
+servers:
+  - url: /
+info:
+  description: Optional requestBody API
+  version: 0.0.1
+  title: Optional requestBody API
+paths:
+  /documents:
+    post:
+      summary: Create a document
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Document successfully created
+          content:
+            application/json:
+              schema:
+                type: object


### PR DESCRIPTION
This PR will fix the optional requestBody behaviour.
See Issue: https://github.com/cdimascio/express-openapi-validator/issues/397