### PR TITLE
Move @types/multer to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "Carmine DiMascio <cdimascio@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@types/multer": "^1.4.4",
     "ajv": "^6.12.5",
     "content-type": "^1.0.4",
     "js-yaml": "^3.14.0",
@@ -49,7 +50,6 @@
     "@types/express": "^4.17.8",
     "@types/mocha": "^8.0.3",
     "@types/morgan": "^1.9.1",
-    "@types/multer": "^1.4.4",
     "@types/node": "^14.6.4",
     "@types/supertest": "^2.0.10",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Types from `@types/multer` are being used in the exported `framework/types.d.ts` file. This breaks the TypeScript build of any project that uses this library but doesn't have `@types/multer` installed. Multer isn't a peerDependency of this library, so it shouldn't be a requirement for projects using express-openapi-validator to install it separately. It should be included as a dependency, and not a devDependency. 

There could potentially be an issue with `@types/express` being used in `framework/types.d.ts` as well, but it's likely that any TypeScript project using this library will already have express types installed separately.