### PR TITLE
Fixed property "parameters" typo

### DIFF
--- a/src/middlewares/parsers/request.schema.preprocessor.ts
+++ b/src/middlewares/parsers/request.schema.preprocessor.ts
@@ -59,7 +59,7 @@ export class RequestSchemaPreprocessor {
 
     const v = pathItem[pathItemKey];
     if (v === parameters) return;
-    const ref = v?.parmeters?.$ref;
+    const ref = v?.parameters?.$ref;
 
     const operationParameters = <
       Array<OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject>


### PR DESCRIPTION
There is a typo in the request.schema.preprocessor.ts file which resulted in unexpected behavior.
