### PR TITLE
(fix) #426 custom resolvers are incompatible with options.apiSpec set to path

### DIFF
--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -318,7 +318,7 @@ export class OpenApiValidator {
           expressRoute.indexOf(baseUrl) === 0
             ? expressRoute.substring(baseUrl.length)
             : expressRoute;
-        router[method.toLowerCase()](path, resolver(basePath, route, this.options.apiSpec));
+        router[method.toLowerCase()](path, resolver(basePath, route, context.apiDoc));
       }
     }
     return router;

--- a/test/operation.handler.spec.ts
+++ b/test/operation.handler.spec.ts
@@ -1,8 +1,11 @@
 import * as path from 'path';
 import * as express from 'express';
 import { expect } from 'chai';
+import * as request from 'supertest';
 import * as OpenApiValidator from '../src';
 import * as resolvers from '../src/resolvers';
+import { createApp } from './common/app';
+import { OpenApiValidatorOpts } from '../src/framework/types';
 
 describe('operation handler', () => {
   let defaultNumberOfRoutes = null;
@@ -83,4 +86,38 @@ describe('operation handler', () => {
 
     // expect(app._router.stack.length).to.be.greaterThan(defaultNumberOfRoutes);
   });
+});
+
+describe('custom operation handler', () => {
+  let app = null;
+  let basePath = null;
+  const apiSpec = path.join(
+    __dirname,
+    'resources/eov-operations.modulepath.yaml',
+  );
+  const handler = {
+    basePath: path.join(__dirname, 'resources/routes'),
+    resolver: resolvers.modulePathResolver,
+  };
+  const eovConf: OpenApiValidatorOpts = {
+    apiSpec,
+    operationHandlers: handler,
+  };
+
+  before(async () => {
+    app = await createApp(eovConf, 3005);
+    basePath = app.basePath;
+  });
+
+  after(async () => app.server.close());
+
+  it('should recognize mapped operation', async () => {
+    return request(app)
+      .get(`${basePath}/ping`)
+      .expect(200)
+      .then((r) => {
+        expect(r.text).to.be.equal('pong');
+      });
+  });
+
 });


### PR DESCRIPTION
Also added a simple test for actually checking that resolver works