### PR TITLE
Escape colons in path. Ref #320

### DIFF
--- a/src/framework/openapi.spec.loader.ts
+++ b/src/framework/openapi.spec.loader.ts
@@ -71,9 +71,9 @@ export class OpenApiSpecLoader {
               }
               const openApiRoute = `${bp}${path}`;
               const expressRoute = `${openApiRoute}`
-                .split('/')
+                .split(':')
                 .map(toExpressParams)
-                .join('/');
+                .join('\\:');
 
               routes.push({
                 basePath: bp,

--- a/test/path.params.spec.ts
+++ b/test/path.params.spec.ts
@@ -22,12 +22,10 @@ describe('path params', () => {
             id: req.params.id,
           });
         });
-        app.get(`${app.basePath}/users:lookup`, (req, res) => {
-          res.json([
-            {
-              id: req.query.name,
-            },
-          ]);
+        app.get(`${app.basePath}/user_lookup\\::name`, (req, res) => {
+          res.json({
+            id: req.params.name,
+          });
         });
         app.get(`${app.basePath}/multi_users/:ids?`, (req, res) => {
           res.json({
@@ -77,11 +75,9 @@ describe('path params', () => {
 
   it("should handle :'s in path parameters", async () =>
     request(app)
-      .get(`${app.basePath}/users:lookup`)
-      .query({ name: 'carmine' })
+      .get(`${app.basePath}/user_lookup:carmine`)
       .expect(200)
       .then((r) => {
-        expect(r.body).to.be.an('array');
-        expect(r.body[0].id).to.equal('carmine');
+        expect(r.body.id).to.equal('carmine');
       }));
 });

--- a/test/resources/path.params.yaml
+++ b/test/resources/path.params.yaml
@@ -54,11 +54,11 @@ paths:
             application/json:
               schema:
                 type: object
-  "/users:lookup":
+  "/user_lookup:{name}":
     get:
       parameters:
         - name: name
-          in: query
+          in: path
           required: true
           schema:
             type: string
@@ -68,9 +68,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/User"
+                $ref: "#/components/schemas/User"
 components:
   schemas:
     User:


### PR DESCRIPTION
Notes:
* Express.js limits allowed characters in path names to `/[A-Za-z0-9_]/`. This allows splitting by colon. But things may get ugly if path names in the spec are not compatible.
* This does not fix handling of colons in base path of the server. I consider fixing this separately.