### PR TITLE
fix: request schema preprocessor and multipart middleware custom formats

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -31,8 +31,9 @@ export type SecurityHandlers = {
   ) => boolean | Promise<boolean>;
 };
 
-export interface MultipartOpts extends ajv.Options {
-  multerOpts: any;
+export interface MultipartOpts {
+  multerOpts: boolean | multer.Options;
+  ajvOpts: ajv.Options;
 }
 
 export interface RequestValidatorOptions

--- a/src/middlewares/openapi.multipart.ts
+++ b/src/middlewares/openapi.multipart.ts
@@ -19,9 +19,7 @@ export function multipart(
   options: MultipartOpts,
 ): OpenApiRequestHandler {
   const mult = multer(options.multerOpts);
-  const Ajv = createRequestAjv(apiDoc, {
-    unknownFormats: options.unknownFormats,
-  });
+  const Ajv = createRequestAjv(apiDoc, { ...options.ajvOpts });
   return (req, res, next) => {
     // TODO check that format: binary (for upload) else do not use multer.any()
     // use multer.none() if no binary parameters exist

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -85,6 +85,7 @@ export class OpenApiValidator {
   }
 
   installMiddleware(spec: Promise<Spec>): OpenApiRequestHandler[] {
+    const { formats } = this.options;
     const middlewares: OpenApiRequestHandler[] = [];
     const pContext = spec.then((spec) => {
       const responseApiDoc = this.options.validateResponses
@@ -97,6 +98,13 @@ export class OpenApiValidator {
         useDefaults: true,
         unknownFormats: this.options.unknownFormats,
         format: this.options.validateFormats,
+        formats: formats.reduce((acc, f) => {
+          acc[f.name] = {
+            type: f.type,
+            validate: f.validate,
+          };
+          return acc;
+        }, {}),
       }).preProcess();
 
       return {

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -85,7 +85,6 @@ export class OpenApiValidator {
   }
 
   installMiddleware(spec: Promise<Spec>): OpenApiRequestHandler[] {
-    const { formats } = this.options;
     const middlewares: OpenApiRequestHandler[] = [];
     const pContext = spec.then((spec) => {
       const responseApiDoc = this.options.validateResponses
@@ -98,7 +97,7 @@ export class OpenApiValidator {
         useDefaults: true,
         unknownFormats: this.options.unknownFormats,
         format: this.options.validateFormats,
-        formats: formats.reduce((acc, f) => {
+        formats: this.options.formats.reduce((acc, f) => {
           acc[f.name] = {
             type: f.type,
             validate: f.validate,
@@ -257,7 +256,17 @@ export class OpenApiValidator {
   private multipartMiddleware(apiDoc: OpenAPIV3.Document) {
     return middlewares.multipart(apiDoc, {
       multerOpts: this.options.fileUploader,
-      unknownFormats: this.options.unknownFormats,
+      ajvOpts: {
+        unknownFormats: this.options.unknownFormats,
+        format: this.options.validateFormats,
+        formats: this.options.formats.reduce((acc, f) => {
+          acc[f.name] = {
+            type: f.type,
+            validate: f.validate,
+          };
+          return acc;
+        }, {}),
+      },
     });
   }
 

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -1,4 +1,5 @@
 import ono from 'ono';
+import ajv = require('ajv');
 import * as express from 'express';
 import * as _uniq from 'lodash.uniq';
 import * as cloneDeep from 'lodash.clonedeep';
@@ -15,6 +16,7 @@ import {
   OpenApiRequestMetadata,
   ValidateSecurityOpts,
   OpenAPIV3,
+  RequestValidatorOptions,
 } from './framework/types';
 import { defaultResolver } from './resolvers';
 import { OperationHandlerOptions } from './framework/types';
@@ -35,6 +37,7 @@ export {
 
 export class OpenApiValidator {
   readonly options: OpenApiValidatorOpts;
+  readonly ajvOpts: AjvOptions;
 
   constructor(options: OpenApiValidatorOpts) {
     this.validateOptions(options);
@@ -82,6 +85,7 @@ export class OpenApiValidator {
     }
 
     this.options = options;
+    this.ajvOpts = new AjvOptions(options);
   }
 
   installMiddleware(spec: Promise<Spec>): OpenApiRequestHandler[] {
@@ -90,21 +94,10 @@ export class OpenApiValidator {
       const responseApiDoc = this.options.validateResponses
         ? cloneDeep(spec.apiDoc)
         : null;
-      new RequestSchemaPreprocessor(spec.apiDoc, {
-        nullable: true,
-        coerceTypes: this.options.coerceTypes,
-        removeAdditional: false,
-        useDefaults: true,
-        unknownFormats: this.options.unknownFormats,
-        format: this.options.validateFormats,
-        formats: this.options.formats.reduce((acc, f) => {
-          acc[f.name] = {
-            type: f.type,
-            validate: f.validate,
-          };
-          return acc;
-        }, {}),
-      }).preProcess();
+      new RequestSchemaPreprocessor(
+        spec.apiDoc,
+        this.ajvOpts.preprocessor,
+      ).preProcess();
 
       return {
         context: new OpenApiContext(spec, this.options.ignorePaths),
@@ -256,17 +249,7 @@ export class OpenApiValidator {
   private multipartMiddleware(apiDoc: OpenAPIV3.Document) {
     return middlewares.multipart(apiDoc, {
       multerOpts: this.options.fileUploader,
-      ajvOpts: {
-        unknownFormats: this.options.unknownFormats,
-        format: this.options.validateFormats,
-        formats: this.options.formats.reduce((acc, f) => {
-          acc[f.name] = {
-            type: f.type,
-            validate: f.validate,
-          };
-          return acc;
-        }, {}),
-      },
+      ajvOpts: this.ajvOpts.multipart,
     });
   }
 
@@ -278,59 +261,18 @@ export class OpenApiValidator {
   }
 
   private requestValidationMiddleware(apiDoc: OpenAPIV3.Document) {
-    const {
-      coerceTypes,
-      unknownFormats,
-      validateRequests,
-      validateFormats,
-      formats,
-    } = this.options;
-    const { allowUnknownQueryParameters } = <ValidateRequestOpts>(
-      validateRequests
+    const requestValidator = new middlewares.RequestValidator(
+      apiDoc,
+      this.ajvOpts.request,
     );
-    const requestValidator = new middlewares.RequestValidator(apiDoc, {
-      nullable: true,
-      coerceTypes,
-      removeAdditional: false,
-      useDefaults: true,
-      unknownFormats,
-      allowUnknownQueryParameters,
-      format: validateFormats,
-      formats: formats.reduce((acc, f) => {
-        acc[f.name] = {
-          type: f.type,
-          validate: f.validate,
-        };
-        return acc;
-      }, {}),
-    });
     return (req, res, next) => requestValidator.validate(req, res, next);
   }
 
   private responseValidationMiddleware(apiDoc: OpenAPIV3.Document) {
-    const {
-      coerceTypes,
-      unknownFormats,
-      validateResponses,
-      validateFormats,
-      formats,
-    } = this.options;
-    const { removeAdditional } = <ValidateResponseOpts>validateResponses;
-
-    return new middlewares.ResponseValidator(apiDoc, {
-      nullable: true,
-      coerceTypes,
-      removeAdditional,
-      unknownFormats,
-      format: validateFormats,
-      formats: formats.reduce((acc, f) => {
-        acc[f.name] = {
-          type: f.type,
-          valdiate: f.validate,
-        };
-        return acc;
-      }, {}),
-    }).validate();
+    return new middlewares.ResponseValidator(
+      apiDoc,
+      this.ajvOpts.response,
+    ).validate();
   }
 
   installOperationHandlers(baseUrl: string, context: OpenApiContext): Router {
@@ -409,5 +351,59 @@ export class OpenApiValidator {
     } else {
       return false;
     }
+  }
+}
+
+class AjvOptions {
+  private options: OpenApiValidatorOpts;
+  constructor(options: OpenApiValidatorOpts) {
+    this.options = options;
+  }
+  get preprocessor(): ajv.Options {
+    return this.baseOptions();
+  }
+
+  get response(): ajv.Options {
+    const { removeAdditional } = <ValidateResponseOpts>(
+      this.options.validateResponses
+    );
+    return {
+      ...this.baseOptions(),
+      useDefaults: false,
+      removeAdditional,
+    };
+  }
+
+  get request(): RequestValidatorOptions {
+    const { allowUnknownQueryParameters } = <ValidateRequestOpts>(
+      this.options.validateRequests
+    );
+    return {
+      ...this.baseOptions(),
+      allowUnknownQueryParameters,
+    };
+  }
+
+  get multipart(): ajv.Options {
+    return this.baseOptions();
+  }
+
+  private baseOptions(): ajv.Options {
+    const { coerceTypes, unknownFormats, validateFormats } = this.options;
+    return {
+      nullable: true,
+      coerceTypes,
+      useDefaults: true,
+      removeAdditional: false,
+      unknownFormats,
+      format: validateFormats,
+      formats: this.options.formats.reduce((acc, f) => {
+        acc[f.name] = {
+          type: f.type,
+          validate: f.validate,
+        };
+        return acc;
+      }, {}),
+    };
   }
 }


### PR DESCRIPTION
Not sure about this, but the `formats` seems required for the request schema preprocessor and the multipart middleware ajv instances.

Moreover, I could not catch the RequestSchemaPreprocessor error (unhandled rejection):

```
Error: unknown format "bigint" is used in schema at path "#/properties/id"
    at Object.generate_format [as code] (./node_modules/ajv/lib/dotjs/format.js:69:15)
    at Object.generate_validate [as validate] (./node_modules/ajv/lib/dotjs/validate.js:374:35)
    at Object.generate_properties [as code] (./node_modules/ajv/lib/dotjs/properties.js:201:26)
    at generate_validate (./node_modules/ajv/lib/dotjs/validate.js:374:35)
    at localCompile (./node_modules/ajv/lib/compile/index.js:88:22)
    at Ajv.compile (./node_modules/ajv/lib/compile/index.js:55:13)
    at Ajv._compile (./node_modules/ajv/lib/ajv.js:348:27)
    at Ajv.getSchema (./node_modules/ajv/lib/ajv.js:204:54)
    at RequestSchemaPreprocessor.traverse (./node_modules/express-openapi-validator/dist/middlewares/parsers/request.schema.preprocessor.js:88:30)
    at RequestSchemaPreprocessor.cleanseContentSchema (./node_modules/express-openapi-validator/dist/middlewares/parsers/request.schema.preprocessor.js:82:14)
```

Finally, I updated the MultipartOpts type in the second commit to accept the ajv options as a property (`ajvOpts`).