### PR TITLE
Accept response validation error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,21 @@ Determines whether the validator should validate responses. Also accepts respons
   }
   ```
 
+  **onError:**
+
+  A function that will be invoked on response validation error, instead of the default handling. Useful if you want to log an error or emit a metric, but don't want to actually fail the request. Receives the validation error and offending response body.
+
+  For example:
+
+  ```
+  validateResponses: {
+    onError: (error, body) => {
+      console.log(`Response body fails validation: `, error);
+      console.debug(body);
+    }
+  }
+  ```
+
 ### ▪️ validateSecurity (optional)
 
 Determines whether the validator should validate securities e.g. apikey, basic, oauth2, openid, etc

--- a/src/framework/modded.express.mung.ts
+++ b/src/framework/modded.express.mung.ts
@@ -36,9 +36,9 @@ mung.json = function json(fn, options) {
 
       // Run the munger
       try {
-        json = fn(json, req, res, next);
+        json = fn(json, req, res);
       } catch (e) {
-        return mung.onError(e, req, res, next, json);
+        return mung.onError(e, req, res, next);
       }
       if (res.headersSent) return res;
 

--- a/src/framework/modded.express.mung.ts
+++ b/src/framework/modded.express.mung.ts
@@ -36,9 +36,9 @@ mung.json = function json(fn, options) {
 
       // Run the munger
       try {
-        json = fn(json, req, res);
+        json = fn(json, req, res, next);
       } catch (e) {
-        return mung.onError(e, req, res, next);
+        return mung.onError(e, req, res, next, json);
       }
       if (res.headersSent) return res;
 

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -47,6 +47,7 @@ export type ValidateRequestOpts = {
 export type ValidateResponseOpts = {
   removeAdditional?: 'failing' | boolean;
   coerceTypes?: boolean | 'array';
+  onError?: (err: InternalServerError, req: Request, res: Response, next: NextFunction, json: any) => void;
 };
 
 export type ValidateSecurityOpts = {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -47,7 +47,7 @@ export type ValidateRequestOpts = {
 export type ValidateResponseOpts = {
   removeAdditional?: 'failing' | boolean;
   coerceTypes?: boolean | 'array';
-  onError?: (err: InternalServerError, req: Request, res: Response, next: NextFunction, json: any) => void;
+  onError?: (err: InternalServerError, json: any) => void;
 };
 
 export type ValidateSecurityOpts = {

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -50,7 +50,7 @@ export class ResponseValidator {
   }
 
   public validate(): RequestHandler {
-    return mung.json((body, req, res, next) => {
+    return mung.json((body, req, res) => {
       if (req.openapi) {
         const openapi = <OpenApiRequestMetadata>req.openapi;
         // instead of openapi.schema, use openapi._responseSchema to get the response copy
@@ -80,7 +80,7 @@ export class ResponseValidator {
         } catch (err) {
           // If a custom error handler was provided, we call that
           if (err instanceof InternalServerError && this.eovOptions.onError) {
-            this.eovOptions.onError(err, req, res, next, body)
+            this.eovOptions.onError(err, body)
           } else {
             // No custom error handler, or something unexpected happen.
             throw err;

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -71,6 +71,7 @@ export class OpenApiValidator {
       options.validateResponses = {
         removeAdditional: false,
         coerceTypes: false,
+        onError: null
       };
     }
 
@@ -272,6 +273,8 @@ export class OpenApiValidator {
     return new middlewares.ResponseValidator(
       apiDoc,
       this.ajvOpts.response,
+      // This has already been converted from boolean if required
+      this.options.validateResponses as ValidateResponseOpts
     ).validate();
   }
 

--- a/test/response.validation.on.error.spec.ts
+++ b/test/response.validation.on.error.spec.ts
@@ -63,7 +63,8 @@ describe(packageJson.name, () => {
       .then((r: any) => {
         const data = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
         expect(r.body).to.eql(data);
+        expect(onErrorArgs.length).to.equal(2);
         expect(onErrorArgs[0].message).to.equal('.response[0].id should be integer');
-        expect(onErrorArgs[4]).to.eql(data);
+        expect(onErrorArgs[1]).to.eql(data);
       }));
 });

--- a/test/response.validation.on.error.spec.ts
+++ b/test/response.validation.on.error.spec.ts
@@ -1,0 +1,69 @@
+import * as path from 'path';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { createApp } from './common/app';
+import * as packageJson from '../package.json';
+
+const apiSpecPath = path.join('test', 'resources', 'response.validation.yaml');
+
+describe(packageJson.name, () => {
+  let app = null;
+
+  let onErrorArgs = null;
+  before(async () => {
+    // set up express app
+    app = await createApp(
+      {
+        apiSpec: apiSpecPath,
+        validateResponses: {
+          onError: function() {
+            onErrorArgs = Array.from(arguments);
+          }
+        },
+      },
+      3005,
+      app => {
+        app.get(`${app.basePath}/users`, (req, res) => {
+          const json = ['user1', 'user2', 'user3'];
+          return res.json(json);
+        });
+        app.get(`${app.basePath}/pets`, (req, res) => {
+          let json = {};
+          if ((req.query.mode = 'bad_type')) {
+            json = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
+          }
+          return res.json(json);
+        });
+        app.post(`${app.basePath}/no_additional_props`, (req, res) => {
+          res.json(req.body);
+        });
+        app.use((err, req, res, next) => {
+          res.status(err.status ?? 500).json({
+            message: err.message,
+            code: err.status ?? 500,
+          });
+        });
+      },
+      false,
+    );
+  });
+
+  afterEach(() => {
+    onErrorArgs = false;
+  })
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('custom error handler invoked if response field has a value of incorrect type', async () =>
+    request(app)
+      .get(`${app.basePath}/pets?mode=bad_type`)
+      .expect(200)
+      .then((r: any) => {
+        const data = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
+        expect(r.body).to.eql(data);
+        expect(onErrorArgs[0].message).to.equal('.response[0].id should be integer');
+        expect(onErrorArgs[4]).to.eql(data);
+      }));
+});

--- a/test/response.validation.on.error.spec.ts
+++ b/test/response.validation.on.error.spec.ts
@@ -23,7 +23,7 @@ describe(packageJson.name, () => {
       },
       3005,
       app => {
-        app.get(`${app.basePath}/users`, (req, res) => {
+        app.get(`${app.basePath}/users`, (_req, res) => {
           const json = ['user1', 'user2', 'user3'];
           return res.json(json);
         });
@@ -34,10 +34,7 @@ describe(packageJson.name, () => {
           }
           return res.json(json);
         });
-        app.post(`${app.basePath}/no_additional_props`, (req, res) => {
-          res.json(req.body);
-        });
-        app.use((err, req, res, next) => {
+        app.use((err, _req, res, _next) => {
           res.status(err.status ?? 500).json({
             message: err.message,
             code: err.status ?? 500,
@@ -49,7 +46,7 @@ describe(packageJson.name, () => {
   });
 
   afterEach(() => {
-    onErrorArgs = false;
+    onErrorArgs = null;
   })
 
   after(() => {
@@ -66,5 +63,14 @@ describe(packageJson.name, () => {
         expect(onErrorArgs.length).to.equal(2);
         expect(onErrorArgs[0].message).to.equal('.response[0].id should be integer');
         expect(onErrorArgs[1]).to.eql(data);
+      }));
+
+  it('custom error handler not invoked on valid response', async () =>
+    request(app)
+      .get(`${app.basePath}/users`)
+      .expect(200)
+      .then((r: any) => {
+        expect(r.body).is.an('array').with.length(3);
+        expect(onErrorArgs).to.equal(null);
       }));
 });


### PR DESCRIPTION
Here's a stab at the feature outlined here: https://github.com/cdimascio/express-openapi-validator/issues/454

This PR adds a new `validateResponses.onError` option. There's no strong contract with the function, but express-openapi-validator will pass the `err` object, as well as the response `data`. Usage might look something like this

```
const handler = (err, data) => {
   console.log('OpenAPI response validation error', err);
};

OpenApiValidator.middleware({
   apiSpec: './spec/openapi.json',
   validateRequests: true,
   validateResponses: { onError: handler }
});
```

