### PR TITLE
Make OpenApiRequest.openapi optional not empty object

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -423,7 +423,7 @@ export interface OpenApiRequestMetadata {
 }
 
 export interface OpenApiRequest extends Request {
-  openapi?: OpenApiRequestMetadata | {};
+  openapi?: OpenApiRequestMetadata;
 }
 
 export type OpenApiRequestHandler = (

--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -37,7 +37,7 @@ export function applyOpenApiMetadata(
         (<any>req.openapi)._responseSchema = (<any>matched)._responseSchema;
       }
     } else if (openApiContext.isManagedRoute(path)) {
-      req.openapi = {};
+      req.openapi = undefined;
     }
     next();
   };


### PR DESCRIPTION
Hi,  I'm not expert enough on this code to be sure that the below is sufficient.  But it appeared that all the other references could handle openapi being undefined.  You'll have to review to be sure I didn't miss anything else.