### PR TITLE
Allowing request body to be coerced

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ Determines whether the validator should validate requests.
   }
   ```
 
-    `allowUnknownQueryParameters` is set for the entire validator. It can be overwritten per-operation using
+  `allowUnknownQueryParameters` is set for the entire validator. It can be overwritten per-operation using
   a custom property `x-allow-unknown-query-parameters`.
 
   For example to allow unknown query parameters on ONLY a single endpoint:
@@ -561,6 +561,7 @@ Determines whether the validator should validate requests.
         responses:
           200:
             description: success
+    ```
 
   **coerceTypes:**
 

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Determines whether the validator should validate requests.
   **coerceTypes:**
 
   - `true` - coerce scalar data types.
-  - `false` - (**default**) do not coerce types. (almost always the desired behavior)
+  - `false` - (**default**) do not coerce types. (more strict, safer)
   - `"array"` - in addition to coercions between scalar types, coerce scalar data to an array with one element and vice versa (as required by the schema).
   For example:
 

--- a/README.md
+++ b/README.md
@@ -543,6 +543,25 @@ Determines whether the validator should validate requests.
   }
   ```
 
+    `allowUnknownQueryParameters` is set for the entire validator. It can be overwritten per-operation using
+  a custom property `x-allow-unknown-query-parameters`.
+
+  For example to allow unknown query parameters on ONLY a single endpoint:
+
+  ```yaml
+  paths:
+    /allow_unknown:
+      get:
+        x-allow-unknown-query-parameters: true
+        parameters:
+          - name: value
+            in: query
+            schema:
+              type: string
+        responses:
+          200:
+            description: success
+
   **coerceTypes:**
 
   - `true` - coerce scalar data types.

--- a/README.md
+++ b/README.md
@@ -565,9 +565,14 @@ Determines whether the validator should validate requests.
 
   **coerceTypes:**
 
+  Determines whether the validator will coerce the request body. Request query and path params, headers, cookies are coerced by default and this setting does not affect that.
+
+  Options:
+
   - `true` - coerce scalar data types.
   - `false` - (**default**) do not coerce types. (more strict, safer)
   - `"array"` - in addition to coercions between scalar types, coerce scalar data to an array with one element and vice versa (as required by the schema).
+
   For example:
 
   ```javascript

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ Determines whether the validator should validate requests.
 
   ```javascript
   validateRequests: {
-    allowUnknownQueryParameters: true;
+    coerceTypes: true;
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -543,6 +543,19 @@ Determines whether the validator should validate requests.
   }
   ```
 
+  **coerceTypes:**
+
+  - `true` - coerce scalar data types.
+  - `false` - (**default**) do not coerce types. (almost always the desired behavior)
+  - `"array"` - in addition to coercions between scalar types, coerce scalar data to an array with one element and vice versa (as required by the schema).
+  For example:
+
+  ```javascript
+  validateRequests: {
+    allowUnknownQueryParameters: true;
+  }
+  ```
+
 ### ▪️ validateResponses (optional)
 
 Determines whether the validator should validate responses. Also accepts response validation options.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-openapi-validator",
+  "name": "@madmango/express-openapi-validator",
   "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-openapi-validator",
+  "name": "@madmango/express-openapi-validator",
   "version": "4.7.1",
   "description": "Automatically validate API requests and responses with OpenAPI 3 and Express.",
   "main": "dist/index.js",

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -42,6 +42,7 @@ export interface RequestValidatorOptions
 
 export type ValidateRequestOpts = {
   allowUnknownQueryParameters?: boolean;
+  coerceTypes?: boolean | 'array';
 };
 
 export type ValidateResponseOpts = {

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -46,7 +46,7 @@ export class RequestValidator {
     this.requestOpts.allowUnknownQueryParameters =
       options.allowUnknownQueryParameters;
     this.ajv = createRequestAjv(apiDoc, { ...options, coerceTypes: true });
-    this.ajvBody = createRequestAjv(apiDoc, { ...options, coerceTypes: false });
+    this.ajvBody = createRequestAjv(apiDoc, options);
   }
 
   public validate(

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -78,6 +78,7 @@ export class OpenApiValidator {
     if (options.validateRequests === true) {
       options.validateRequests = {
         allowUnknownQueryParameters: false,
+        coerceTypes: false
       };
     }
 
@@ -317,17 +318,7 @@ export class OpenApiValidator {
       );
     }
 
-    const coerceResponseTypes = options?.validateResponses?.['coerceTypes'];
-    if (options.coerceTypes != null && coerceResponseTypes != null) {
-      throw ono(
-        'coerceTypes and validateResponses.coerceTypes are mutually exclusive',
-      );
-    }
-
     if (options.coerceTypes) {
-      if (options?.validateResponses) {
-        options.validateResponses['coerceTypes'] = true;
-      }
       console.warn('coerceTypes is deprecated.');
     }
 
@@ -390,12 +381,13 @@ class AjvOptions {
   }
 
   get request(): RequestValidatorOptions {
-    const { allowUnknownQueryParameters } = <ValidateRequestOpts>(
+    const { allowUnknownQueryParameters, coerceTypes } = <ValidateRequestOpts>(
       this.options.validateRequests
     );
     return {
       ...this.baseOptions(),
       allowUnknownQueryParameters,
+      coerceTypes
     };
   }
 

--- a/test/request.body.validation.coerce.types.spec.ts
+++ b/test/request.body.validation.coerce.types.spec.ts
@@ -1,0 +1,101 @@
+import * as path from 'path';
+import * as request from 'supertest';
+import { createApp } from './common/app';
+
+describe('request body validation coercion', () => {
+  let coerceApp = null;
+  let nonCoerceApp = null;
+
+  const defineRoutes = app => {
+    app.post(`${app.basePath}/coercion_test`, (req, res) => {
+      res.status(200).send()
+    }
+    )
+  }
+
+  before(async () => {
+    // Set up the express app
+    const apiSpec = path.join('test', 'resources', 'request.bodies.ref.yaml');
+    coerceApp = await createApp(
+      {
+        apiSpec,
+        validateRequests: {
+          coerceTypes: true
+        },
+      },
+      3005,
+      defineRoutes,
+      true,
+    );
+
+    nonCoerceApp = await createApp(
+      {
+        apiSpec,
+        // not specifying coercion as it should be false by default
+      },
+      3006,
+      defineRoutes,
+      true,
+    );
+  });
+
+  after(() => {
+    coerceApp.server.close();
+    nonCoerceApp.server.close();
+  });
+
+  it('should return 200 if coercion is enabled and the type is correct', async () => {
+    return request(coerceApp)
+      .post(`${coerceApp.basePath}/coercion_test`)
+      .set('accept', 'application/json')
+      .set('content-type', 'application/json')
+      .send({
+        aNumberProperty: 4
+      })
+      .expect(200)
+  });
+
+  it('should return 200 if coercion is enabled and the type is incorrect but can be coerced', async () => {
+    return request(coerceApp)
+      .post(`${coerceApp.basePath}/coercion_test`)
+      .set('accept', 'application/json')
+      .set('content-type', 'application/json')
+      .send({
+        aNumberProperty: '4'
+      })
+      .expect(200)
+  });
+
+  it('should return 400 if coercion is enabled and the type is incorrect and cannot be coerced', async () => {
+    return request(coerceApp)
+      .post(`${coerceApp.basePath}/coercion_test`)
+      .set('accept', 'application/json')
+      .set('content-type', 'application/json')
+      .send({
+        aNumberProperty: 'this is a string and definitely not a number'
+      })
+      .expect(400)
+  });
+
+  it('should return 200 if coercion is disabled and the type is correct', async () => {
+    return request(nonCoerceApp)
+      .post(`${nonCoerceApp.basePath}/coercion_test`)
+      .set('accept', 'application/json')
+      .set('content-type', 'application/json')
+      .send({
+        aNumberProperty: 4
+      })
+      .expect(200)
+  });
+
+  it('should return 400 if coercion is disabled and the type is incorrect', async () => {
+    return request(nonCoerceApp)
+      .post(`${nonCoerceApp.basePath}/coercion_test`)
+      .set('accept', 'application/json')
+      .set('content-type', 'application/json')
+      .send({
+        aNumberProperty: '4'
+      })
+      .expect(400)
+  });
+});

--- a/test/resources/request.bodies.ref.yaml
+++ b/test/resources/request.bodies.ref.yaml
@@ -17,7 +17,14 @@ paths:
               properties:
                 id:
                   type: string
-                
+      responses:
+        '200':
+          description: OK
+
+  /coercion_test:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/CoercionTestBody'
       responses:
         '200':
           description: OK
@@ -81,6 +88,11 @@ components:
           format: phone-number
       required:
         - testPropertyTwo
+    CoercionTest:
+      type: object
+      properties:
+        aNumberProperty:
+          type: number
 
   requestBodies:
     TestBody:
@@ -107,3 +119,9 @@ components:
         '*/*':
           schema:
             type: string
+    CoercionTestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CoercionTest'


### PR DESCRIPTION
We talked about implementing it in #387 and #396

Hope the code is fine, let me know if it needs any tweaks, it's still false as default so it shouldn't affect current behaviour in anyone's projects.

Added tests to cover new features.

I've also made a change to the global `coerceTypes` setting, it wasn't affecting anything apart from setting it to true on response validation which seems counterintuitive, especially that now we have both response and request validation so I just removed the code that seemed redundant on [these lines](https://github.com/cdimascio/express-openapi-validator/pull/468/files#diff-45e81b10790fecfe1b0108e22869e679c99c58f5a51d8d2b35c5442f37a5cb60L320-L330)