### PR TITLE
Fix using discriminators.

### DIFF
--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -262,6 +262,9 @@ export class SchemaPreprocessor {
 
     if (xOf && schemaObj?.discriminator?.propertyName && !o.discriminator) {
       const options = schemaObj[xOf].flatMap((refObject) => {
+        if (refObject['$ref'] === undefined) {
+          return [];
+        }
         const keys = this.findKeys(
           schemaObj.discriminator.mapping,
           (value) => value === refObject['$ref'],


### PR DESCRIPTION
If an object's reference has already been resolved, or if the object is not a reference, the code will abort with an error like:

```
node_modules/express-openapi-validator/dist/middlewares/parsers/schema.preprocessor.js:366
        return ref.split('/components/schemas/')[1];

TypeError: Cannot read property 'split' of undefined
    at SchemaPreprocessor.getKeyFromRef (node_modules/express-openapi-validator/dist/middlewares/parsers/schema.preprocessor.js:366:20)
    at node_modules/express-openapi-validator/dist/middlewares/parsers/schema.preprocessor.js:194:34
    at Array.flatMap (<anonymous>)
```

In [this zip](https://github.com/cdimascio/express-openapi-validator/files/5770583/openapi.zip) are two files that exhibit this issue.
