### PR TITLE
feat: 3.1.0 roles in security schema for all types

### DIFF
--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -279,8 +279,6 @@ class AuthValidator {
       if (type === 'basic' && !authHeader.includes('basic')) {
         throw Error(`Authorization header with scheme 'Basic' required`);
       }
-
-      this.dissallowScopes();
     }
   }
 
@@ -300,17 +298,6 @@ class AuthValidator {
           throw Error(`cookie '${scheme.name}' required`);
         }
       }
-
-      this.dissallowScopes();
-    }
-  }
-
-  private dissallowScopes(): void {
-    if (this.scopes.length > 0) {
-      // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#security-requirement-object
-      throw new InternalServerError({
-        message: "scopes array must be empty for security type 'http'",
-      });
     }
   }
 }

--- a/test/security.handlers.spec.ts
+++ b/test/security.handlers.spec.ts
@@ -351,18 +351,6 @@ describe('security.handlers', () => {
       });
   });
 
-  it('should return 500 if scopes are no allowed', async () =>
-    request(app)
-      .get(`${basePath}/api_key_with_scopes`)
-      .set('X-Api-Key', 'XXX')
-      .expect(500)
-      .then((r) => {
-        const body = r.body;
-        expect(body.message).to.equal(
-          "scopes array must be empty for security type 'http'",
-        );
-      }));
-
   it('should return 200 if api_key or anonymous and no api key is supplied', async () => {
     const validateSecurity = <ValidateSecurityOpts>eovConf.validateSecurity;
     validateSecurity.handlers.ApiKeyAuth = <any>((req, scopes, schema) => true);


### PR DESCRIPTION
The OpenAPI 3.1.0 spec, currently in RC2, has formalized that the security schema will allow all security types to specify "roles" using the same syntax as OAuth2 and OIDC scopes: by simply putting strings into what previously was forced to be an empty array. These strings do not need to be enumerated in the security component, as they do with OAuth2 and OIDC.

Conveniently, this is a new feature that can be implemented entirely by deleting code! This PR allows roles to be specified, using the same scopes mechanism already in place.