### PR TITLE
improve: added parameter definition to route openapi

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -433,6 +433,7 @@ export interface OpenApiRequestMetadata {
   openApiRoute: string;
   pathParams: { [index: string]: string };
   schema: OpenAPIV3.OperationObject;
+  parameters: Array<ParameterObject>;
 }
 
 export interface OpenApiRequest extends Request {

--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -24,11 +24,23 @@ export function applyOpenApiMetadata(
     const matched = lookupRoute(req);
     if (matched) {
       const { expressRoute, openApiRoute, pathParams, schema } = matched;
+      const parameters = [];
+      for (const param of schema?.parameters || []) {
+        if (param.$ref) {
+          const p = param.$ref.replace('#/components/parameters/', '');
+          parameters.push(
+            openApiContext.apiDoc.components.parameters[p]
+          );
+        } else {
+          parameters.push(param);
+        }
+      }
       req.openapi = {
         expressRoute: expressRoute,
         openApiRoute: openApiRoute,
         pathParams: pathParams,
         schema: schema,
+        parameters: parameters,
       };
       req.params = pathParams;
       if (responseApiDoc) {


### PR DESCRIPTION
Hi there,

I've added slight modification to dereference parameters so that my route handler can use that to extract all parameters from `req` object.