### PR TITLE
Add validateApiDoc props in OpenApiValidatorOpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ OpenApiValidator.middleware({
   apiSpec: './openapi.yaml',
   validateRequests: true,
   validateResponses: true,
+  validateApiSpec: true,
   validateSecurity: {
     handlers: {
       ApiKeyAuth: (req, scopes, schema) => {
@@ -523,13 +524,6 @@ or
   }
 }
 ```
-
-### ▪️ validateApiDoc (optional)
-
-Determines whether the validator should validate the OpenAPI specification.
-
-- `true` (**default**) - validate the OpenAPI specification.
-- `false` - do not validate the OpenAPI specification.
 
 ### ▪️ validateRequests (optional)
 
@@ -653,6 +647,14 @@ Determines whether the validator should validate securities e.g. apikey, basic, 
     }
   }
   ```
+
+### ▪️ validateApiSpec (optional)
+
+Determines whether the validator should validate the OpenAPI specification. Useful if you are certain that the api spec is syntactically correct and want to bypass this check.
+
+- `true` (**default**) - validate the OpenAPI specification.
+- `false` - do not validate the OpenAPI specification.
+
 
 ### ▪️ formats (optional)
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,13 @@ or
 }
 ```
 
+### ▪️ validateApiDoc (optional)
+
+Determines whether the validator should validate the OpenAPI specification.
+
+- `true` (**default**) - validate the OpenAPI specification.
+- `false` - do not validate the OpenAPI specification.
+
 ### ▪️ validateRequests (optional)
 
 Determines whether the validator should validate requests.

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -31,14 +31,14 @@ export class OpenAPIFramework {
         return acc;
       }, new Set<string>()),
     );
-    const validateApiDoc =
-      'validateApiDoc' in args ? !!args.validateApiDoc : true;
+    const validateApiSpec =
+      'validateApiSpec' in args ? !!args.validateApiSpec : true;
     const validator = new OpenAPISchemaValidator({
       version: apiDoc.openapi,
       // extensions: this.apiDoc[`x-${args.name}-schema-extension`],
     });
 
-    if (validateApiDoc) {
+    if (validateApiSpec) {
       const apiDocValidation = validator.validate(apiDoc);
 
       if (apiDocValidation.errors.length) {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -76,7 +76,7 @@ export type Serializer = {
 
 export interface OpenApiValidatorOpts {
   apiSpec: OpenAPIV3.Document | string;
-  validateApiDoc?: boolean;
+  validateApiSpec?: boolean;
   validateResponses?: boolean | ValidateResponseOpts;
   validateRequests?: boolean | ValidateRequestOpts;
   validateSecurity?: boolean | ValidateSecurityOpts;
@@ -413,7 +413,7 @@ export interface OpenAPIFrameworkPathObject {
 
 interface OpenAPIFrameworkArgs {
   apiDoc: OpenAPIV3.Document | string;
-  validateApiDoc?: boolean;
+  validateApiSpec?: boolean;
   $refParser?: {
     mode: 'bundle' | 'dereference';
   };

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -76,6 +76,7 @@ export type Serializer = {
 
 export interface OpenApiValidatorOpts {
   apiSpec: OpenAPIV3.Document | string;
+  validateApiDoc?: boolean;
   validateResponses?: boolean | ValidateResponseOpts;
   validateRequests?: boolean | ValidateRequestOpts;
   validateSecurity?: boolean | ValidateSecurityOpts;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ function openapiValidator(options: OpenApiValidatorOpts) {
   return oav.installMiddleware(
     new OpenApiSpecLoader({
       apiDoc: options.apiSpec,
+      validateApiDoc: options.validateApiDoc,
       $refParser: options.$refParser,
     }).load(),
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ function openapiValidator(options: OpenApiValidatorOpts) {
   return oav.installMiddleware(
     new OpenApiSpecLoader({
       apiDoc: options.apiSpec,
-      validateApiDoc: options.validateApiDoc,
+      validateApiSpec: options.validateApiSpec,
       $refParser: options.$refParser,
     }).load(),
   );


### PR DESCRIPTION
Hi, i added validateApiDoc props in OpenApiValidatorOpts interface. I noticed that it was missing, watching these few lines:

https://github.com/cdimascio/express-openapi-validator/blob/e57e04e446f31f4a5b11227d265a5ed010a08493/src/framework/index.ts#L34-L54

Now it is possible to disable the OpenAPI specification validation.

```ts
app.use(
  OpenApiValidator.middleware({
    apiSpec: './openapi.yaml',
    validateApiDoc: false // true by default
  }),
);
```