### PR TITLE
Fix: electron asar - failed to open spec dir

### DIFF
--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -87,7 +87,7 @@ export class OpenAPIFramework {
           return $refParser.mode === 'dereference'
             ? $RefParser.dereference(absolutePath)
             : $RefParser.bundle(absolutePath);
-        }
+        } finally {}
       } else {
         throw new Error(
           `${this.loggingPrefix}spec could not be read at ${filePath}`,

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -82,11 +82,9 @@ export class OpenAPIFramework {
       const absolutePath = path.resolve(origCwd, filePath);
       if (fs.existsSync(absolutePath)) {
         // Get document, or throw exception on error
-        try {
-          return $refParser.mode === 'dereference'
-            ? $RefParser.dereference(absolutePath)
-            : $RefParser.bundle(absolutePath);
-        } finally {}
+        return $refParser.mode === 'dereference'
+          ? $RefParser.dereference(absolutePath)
+          : $RefParser.bundle(absolutePath);
       } else {
         throw new Error(
           `${this.loggingPrefix}spec could not be read at ${filePath}`,

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -79,7 +79,6 @@ export class OpenAPIFramework {
     // We need this workaround ( use '$RefParser.dereference' instead of '$RefParser.bundle' ) if asked by user
     if (typeof filePath === 'string') {
       const origCwd = process.cwd();
-      const specDir = path.resolve(origCwd, path.dirname(filePath));
       const absolutePath = path.resolve(origCwd, filePath);
       if (fs.existsSync(absolutePath)) {
         // Get document, or throw exception on error

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -84,12 +84,9 @@ export class OpenAPIFramework {
       if (fs.existsSync(absolutePath)) {
         // Get document, or throw exception on error
         try {
-          process.chdir(specDir);
           return $refParser.mode === 'dereference'
             ? $RefParser.dereference(absolutePath)
             : $RefParser.bundle(absolutePath);
-        } finally {
-          process.chdir(origCwd);
         }
       } else {
         throw new Error(


### PR DESCRIPTION
**This PR attempts to resolve the issue described in ticket #530 "electron asar - failed to open spec dir".**

Although the removed statements seem to have had intention, their absence does not cause any issue with the current mocha test suite. Locally, the PR runs with 337 test passed and 4 pending - exactly like beforehand. To me it makes sense that the code works without these statements since actual reading takes place using the absolute path only.

It remains to be discussed wether this is a proper fix for the issue (or just a workaround) and if this may cause issues for some users.

Thank you very much @cdimascio for your help :)