### PR TITLE
Fix Mutation of API Spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as cloneDeep from 'lodash.clonedeep';
 import * as res from './resolvers';
 import { OpenApiValidator, OpenApiValidatorOpts } from './openapi.validator';
 import { OpenApiSpecLoader } from './framework/openapi.spec.loader';
@@ -34,7 +35,7 @@ function openapiValidator(options: OpenApiValidatorOpts) {
 
   return oav.installMiddleware(
     new OpenApiSpecLoader({
-      apiDoc: options.apiSpec,
+      apiDoc: cloneDeep(options.apiSpec),
       validateApiSpec: options.validateApiSpec,
       $refParser: options.$refParser,
     }).load(),

--- a/test/535.spec.ts
+++ b/test/535.spec.ts
@@ -1,0 +1,67 @@
+import * as express from 'express';
+import { Server } from 'http';
+import * as request from 'supertest';
+import * as OpenApiValidator from '../src';
+import { OpenAPIV3 } from '../src/framework/types';
+import { startServer } from './common/app.common';
+import { deepStrictEqual } from 'assert';
+
+describe('#535 - calling `middleware()` multiple times', () => {
+  it('does not mutate the API specification', async () => {
+    const apiSpec = createApiSpec();
+
+    const app = await createApp(apiSpec);
+    await request(app).get('/ping/GNU Sir Terry').expect(200, 'GNU Sir Terry');
+    app.server.close();
+
+    deepStrictEqual(apiSpec, createApiSpec());
+  });
+});
+
+async function createApp(
+  apiSpec: OpenAPIV3.Document,
+): Promise<express.Express & { server?: Server }> {
+  const app = express();
+
+  app.use(
+    OpenApiValidator.middleware({
+      apiSpec,
+      validateRequests: true,
+    }),
+  );
+  app.use(
+    express.Router().get('/ping/:value', (req, res) => {
+      res.status(200).send(req.params.value);
+    }),
+  );
+
+  await startServer(app, 3001);
+  return app;
+}
+
+function createApiSpec(): OpenAPIV3.Document {
+  return {
+    openapi: '3.0.3',
+    info: {
+      title: 'Ping API',
+      version: '1.0.0',
+    },
+    paths: {
+      '/ping/{value}': {
+        parameters: [
+          {
+            in: 'path',
+            name: 'value',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        get: {
+          responses: {
+            '200': { description: 'pong!' },
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
Fixes https://github.com/cdimascio/express-openapi-validator/issues/535

I found the line that mutates the parameters causing the error here: https://github.com/cdimascio/express-openapi-validator/blob/v4.10.11/src/middlewares/parsers/schema.preprocessor.ts#L489

It doesn't seem easy to change that behaviour thoug. About the idea of using a set, this seems to me like it could hide some actual errors. So I opted for just cloning the spec passed to `middleware()`. That should avoid other unexpected behaviour, too.

