### PR TITLE
propagate validateApiSpec: false to ajv

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,9 @@ Determines whether the validator should validate the OpenAPI specification. Usef
 
 - `true` (**default**) - validate the OpenAPI specification.
 - `false` - do not validate the OpenAPI specification.
-
+- `{ ... }`
+  - `suppressValidation` same as boolean false
+  - `deeplySuppress` also notify dependencies to not validate
 
 ### ▪️ formats (optional)
 

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -36,6 +36,7 @@ export class OpenAPIFramework {
     const validator = new OpenAPISchemaValidator({
       version: apiDoc.openapi,
       // extensions: this.apiDoc[`x-${args.name}-schema-extension`],
+      validateApiSpec,
     });
 
     if (validateApiSpec) {

--- a/src/framework/openapi.schema.validator.ts
+++ b/src/framework/openapi.schema.validator.ts
@@ -6,8 +6,15 @@ import { OpenAPIV3 } from './types.js';
 
 export class OpenAPISchemaValidator {
   private validator: Ajv.ValidateFunction;
-  constructor({ version }: { version: string; extensions?: object }) {
-    const v = new Ajv({ schemaId: 'auto', allErrors: true });
+  constructor({ version, validateApiSpec }: { version: string, validateApiSpec: boolean, extensions?: object  }) {
+    const options: any = {
+      schemaId: 'auto',
+      allErrors: true,
+    };
+    if (!validateApiSpec) {
+      options.validateSchema = false;
+    }
+    const v = new Ajv(options);
     v.addMetaSchema(draftSchema);
 
     const ver = version && parseInt(String(version), 10);

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -49,6 +49,12 @@ export type ValidateRequestOpts = {
   removeAdditional?: boolean | 'all' | 'failing';
 };
 
+export type ValidateApiSpecOpts = {
+  suppressValidation?: boolean;
+  // suppress validation in ajv and apidevtools/json-schema-ref-parser
+  deeplySuppress?: boolean;
+};
+
 export type ValidateResponseOpts = {
   removeAdditional?: boolean | 'all' | 'failing';
   coerceTypes?: boolean | 'array';
@@ -108,7 +114,7 @@ export type SerDesMap = {
 
 export interface OpenApiValidatorOpts {
   apiSpec: OpenAPIV3.Document | string;
-  validateApiSpec?: boolean;
+  validateApiSpec?: boolean | ValidateApiSpecOpts;
   validateResponses?: boolean | ValidateResponseOpts;
   validateRequests?: boolean | ValidateRequestOpts;
   validateSecurity?: boolean | ValidateSecurityOpts;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   NotFound,
   Unauthorized,
   Forbidden,
+  ValidateApiSpecOpts,
 } from './framework/types';
 
 // export default openapiValidator;
@@ -35,10 +36,15 @@ function openapiValidator(options: OpenApiValidatorOpts) {
   const oav = new OpenApiValidator(options);
   exports.middleware._oav = oav;
 
+  const shouldValidate = (options): boolean => {
+    const { suppressValidation, deeplySuppress } = <ValidateApiSpecOpts>(options.validateApiSpec || {});
+    return !(suppressValidation || deeplySuppress || options.validateApiSpec === false);
+  }
+
   return oav.installMiddleware(
     new OpenApiSpecLoader({
       apiDoc: cloneDeep(options.apiSpec),
-      validateApiSpec: options.validateApiSpec,
+      validateApiSpec: shouldValidate(options),
       $refParser: options.$refParser,
     }).load(),
   );

--- a/test/ajv.options.ts
+++ b/test/ajv.options.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import { AjvOptions } from '../src/openapi.validator';
+
+describe('AjvOptions', () => {
+  const baseOptions = {
+    apiSpec: './spec',
+    validateApiSpec: false,
+    validateRequests: {},
+    serDes: [],
+    formats: [],
+  };
+
+  it('defaults to validateSchema:true', async () => {
+    const ajv = new AjvOptions(baseOptions);
+    const options = ajv.request;
+    expect(options.validateSchema).to.be.true;
+  });
+
+  it('returns to validateSchema:true with validateApiSpec: false', async () => {
+    const ajv = new AjvOptions(
+      {
+        ...baseOptions,
+        ...{ validateApiSpec: false }
+      }
+    );
+    const options = ajv.request;
+    expect(options.validateSchema).to.be.true;
+  });
+
+  it('returns to validateSchema:true with validateApiSpec: {}', async () => {
+    const ajv = new AjvOptions(
+      {
+        ...baseOptions,
+        ...{ validateApiSpec: {} }
+      }
+    );
+    const options = ajv.request;
+    expect(options.validateSchema).to.be.true;
+  });
+
+  it('returns to validateSchema:true with suppressValidation: true', async () => {
+    const ajv = new AjvOptions(
+      {
+        ...baseOptions,
+        ...{
+          validateApiSpec: {
+            suppressValidation: true
+          }
+        }
+      }
+    );
+    const options = ajv.request;
+    expect(options.validateSchema).to.be.true;
+  });
+
+  it('returns to validateSchema:false with deeplySuppress: true', async () => {
+    const ajv = new AjvOptions(
+      {
+        ...baseOptions,
+        ...{
+          validateApiSpec: {
+            deeplySuppress: true
+          }
+        }
+      }
+    );
+    const options = ajv.request;
+    expect(options.validateSchema).to.be.false;
+  });
+});


### PR DESCRIPTION
resolves issue [541](https://github.com/cdimascio/express-openapi-validator/issues/541)

For context. We have a somewhat large spec file and would like to avoid the overhead of validating the spec on every request. There is also a concern that concurrent merges to our deploy could interject duplicate enum values, etc which would effectively kill the api. I created a test in our system specifically for validating the spec.

There is possibly a better way to do this and I am open to any suggestions that you might have.

For example, we could change the validateApiSpec key to an object|boolean (see [OpenApiValidatorOpts.validateResponses](https://github.com/cdimascio/express-openapi-validator/blob/master/src/framework/types.ts#L112)) so that users of this package can decide how deeply they want to disable the validation.

Also, there is probably a cleaner way to pass the validateSchema flag to ajv than to override the options on each validator.

I didn't add any new tests yet but it is not breaking any existing tests and manually verified that ajv/lib/ajv.js:validateSchema does not get called with this override

-- edit --

I updated the branch so that it allows for passing in boolean or validation suppression options and added validateSchema to the baseOptions response