### PR TITLE
fix: correctly handle default values of deepObject query params

### DIFF
--- a/test/resources/serialized-deep-object.objects.yaml
+++ b/test/resources/serialized-deep-object.objects.yaml
@@ -1,0 +1,62 @@
+openapi: "3.0.2"
+info:
+  version: 1.0.0
+  title: Request Query Serialization
+  description: Request Query Serialization Test
+
+servers:
+  - url: /v1/
+
+paths:
+  /deep_object:
+    x-vendorExtension1: accounts
+    get:
+      x-vendorExtension2: accounts
+      summary: "retrieve a deep object"
+      operationId: getDeepObject
+      parameters:
+        - in: query
+          style: deepObject
+          name: settings
+          schema:
+            type: object
+            required:
+              - state
+            properties:
+              tag_ids:
+                type: array
+                items:
+                  type: integer
+                  minimum: 0
+                minItems: 1
+              state:
+                type: string
+                enum: ["default", "validated", "pending"]
+                default: "default"
+                description: "Filter the tags by their validity. The default value ('default') stands for no filtering."
+              greeting:
+                type: string
+                default: "hello"
+      responses:
+        "200":
+          description: the object
+
+components:
+  schemas:
+    Deep:
+      type: object
+      properties:
+        tag_ids:
+          type: array
+          items:
+            type: integer
+            minimum: 0
+          minItems: 1
+        state:
+          type: string
+          enum: ["default", "validated", "pending"]
+          default: "default"
+          description: "Filter the tags by their validity. The default value ('default') stands for no filtering."
+        greeting:
+          type: string
+          default: "hello"

--- a/test/resources/serialized.objects.defaults.yaml
+++ b/test/resources/serialized.objects.defaults.yaml
@@ -14,6 +14,7 @@ components:
           default: 25
           type: integer
       type: object
+      default: {}
     Sorting:
       properties:
         field:
@@ -29,6 +30,7 @@ components:
             - DESC
           type: string
       type: object
+      default: {}
 info:
   description: API
   title: API

--- a/test/serialized-deep-object.objects.spec.ts
+++ b/test/serialized-deep-object.objects.spec.ts
@@ -1,0 +1,50 @@
+import * as path from 'path';
+import * as express from 'express';
+import * as request from 'supertest';
+import * as packageJson from '../package.json';
+import { expect } from 'chai';
+import { createApp } from './common/app';
+
+describe(packageJson.name, () => {
+  let app = null;
+
+  before(async () => {
+    // Set up the express app
+    const apiSpec = path.join('test', 'resources', 'serialized-deep-object.objects.yaml');
+    app = await createApp({ apiSpec }, 3005, (app) =>
+      app.use(
+        `${app.basePath}`,
+        express
+          .Router()
+          .get(`/deep_object`, (req, res) => res.json(req.query))
+      ),
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should explode deepObject query params', async () =>
+    request(app)
+      .get(`${app.basePath}/deep_object?settings[state]=default`)
+      .expect(200)
+      .then((r) => {
+        const expected = {
+          settings: {
+            greeting: 'hello',
+            state: 'default'
+          }
+        };
+        expect(r.body).to.deep.equals(expected);
+      }));
+
+  it('should explode deepObject query params (optional query param)', async () =>
+    request(app)
+      .get(`${app.basePath}/deep_object`)
+      .expect(200)
+      .then((r) => {
+        const expected = {};
+        expect(r.body).to.deep.equals(expected);
+      }));
+});


### PR DESCRIPTION
This PR fixes a problem with optional `deepObject` `query` parameters with required keys in the schema.