### PR TITLE
fix: Relax Allow Header Test

### DIFF
--- a/test/allow.header.spec.ts
+++ b/test/allow.header.spec.ts
@@ -18,12 +18,15 @@ describe(packageJson.name, () => {
     app.server.close();
   });
 
-  it('adds allow header to 405 - Method Not Allowed', async () =>
+  it('adds "Allow" header to 405 - Method Not Allowed', async () =>
     request(app)
       .put('/v1/pets/greebo')
       .expect(405)
       .then((response) => {
-        expect(response.header).to.include({ allow: 'POST, GET' });
+        expect(response.header.allow.split(', ')).to.have.members([
+          'GET',
+          'POST',
+        ]);
       }));
 });
 


### PR DESCRIPTION
Fixes bad test in #560. Tested with Node 10 and Node 15.

Problem: The test asserted the order of methods in the Allow header. The order is irrelevant for the header and not guaranteed by the code, so that the test failed using Node 10.

Solution: Adjust the assertion to check the returned methods irrespective of order.