### PR TITLE
feat: add req to onError handler for response validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,14 +643,15 @@ Determines whether the validator should validate responses. Also accepts respons
 
   **onError:**
 
-  A function that will be invoked on response validation error, instead of the default handling. Useful if you want to log an error or emit a metric, but don't want to actually fail the request. Receives the validation error and offending response body.
+  A function that will be invoked on response validation error, instead of the default handling. Useful if you want to log an error or emit a metric, but don't want to actually fail the request. Receives the validation error, the offending response body, and the express request object.
 
   For example:
 
   ```
   validateResponses: {
-    onError: (error, body) => {
+    onError: (error, body, req) => {
       console.log(`Response body fails validation: `, error);
+      console.log(`Emitted from:`, req.originalUrl);
       console.debug(body);
     }
   }

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -52,7 +52,7 @@ export type ValidateRequestOpts = {
 export type ValidateResponseOpts = {
   removeAdditional?: boolean | 'all' | 'failing';
   coerceTypes?: boolean | 'array';
-  onError?: (err: InternalServerError, json: any) => void;
+  onError?: (err: InternalServerError, json: any, req: Request) => void;
 };
 
 export type ValidateSecurityOpts = {

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -80,7 +80,7 @@ export class ResponseValidator {
         } catch (err) {
           // If a custom error handler was provided, we call that
           if (err instanceof InternalServerError && this.eovOptions.onError) {
-            this.eovOptions.onError(err, body)
+            this.eovOptions.onError(err, body, req)
           } else {
             // No custom error handler, or something unexpected happen.
             throw err;

--- a/test/response.validation.on.error.spec.ts
+++ b/test/response.validation.on.error.spec.ts
@@ -65,9 +65,12 @@ describe(packageJson.name, () => {
       .then((r: any) => {
         const data = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
         expect(r.body).to.eql(data);
-        expect(onErrorArgs.length).to.equal(2);
+        expect(onErrorArgs.length).to.equal(3);
         expect(onErrorArgs[0].message).to.equal('.response[0].id should be integer');
         expect(onErrorArgs[1]).to.eql(data);
+        expect(onErrorArgs[2].query).to.eql({
+          mode: 'bad_type'
+        });
       }));
 
   it('custom error handler not invoked on valid response', async () =>
@@ -86,7 +89,7 @@ describe(packageJson.name, () => {
       .then((r: any) => {
         const data = [{ id: 'bad_id_throw', name: 'name', tag: 'tag' }];
         expect(r.body.message).to.equal('error in onError handler');
-        expect(onErrorArgs.length).to.equal(2);
+        expect(onErrorArgs.length).to.equal(3);
         expect(onErrorArgs[0].message).to.equal('.response[0].id should be integer');
         expect(onErrorArgs[1]).to.eql(data);
       }));


### PR DESCRIPTION
Hello 👋 

First of all thanks for this project, we've been using it in my company for some time now and it's really helpful 👍 

The goal of this PR is simply to add the express request object to the `onError` handler for response validation. Our use case is that in case of error, we want to log the failing response with our logger, which is bound to the request (so that we have the request context), but I think that we can imagine a lot of useful use-cases to use the request here :) 