### PR TITLE
Publish generated source maps to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -26,7 +26,6 @@ a_reference
 .nyc_output
 jest
 /coverage
-*.map
 .coverall.yml
 /uploads
 /greenkeeper.json


### PR DESCRIPTION
Hello!

💁‍♀️  This PR removes the `*.map` rule from `.npmignore` with the intent that source maps are published in future NPM releases.

I somewhat-often find myself setting breakpoints in dependencies during development to either be able to trace what seems like a bug or simply to figure out how a dependency is working in order to be able to contribute. Today, when I launch my debugger, I get a slew of "errors" complaining about not being able to find source maps for this package:

```
Could not read source map for file:///<snip>/node_modules/express-openapi-validator/dist/index.js: 
ENOENT: no such file or directory, open '<snip>/node_modules/express-openapi-validator/dist/index.js.map'
```

This repeats for basically every file in `dist`.

There may be more to this PR than simply removing the `*.map` rule, but I would propose that source maps should be distributed as part of the NPM release process and this seemed like the first step. As far as I can tell, the `tsconfig` is already configured to generate source maps.

Please let me know if there's further work to be done here and I'll be happy to help!