### PR TITLE
Handle bad URI

### DIFF
--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -3,6 +3,7 @@ import { pathToRegexp } from 'path-to-regexp';
 import { Response, NextFunction } from 'express';
 import { OpenApiContext } from '../framework/openapi.context';
 import {
+  BadRequest,
   MethodNotAllowed,
   NotFound,
   OpenApiRequest,
@@ -81,17 +82,24 @@ export function applyOpenApiMetadata(
 
       if (matchedRoute) {
         const paramKeys = keys.map((k) => k.name);
-        const paramsVals = matchedRoute.slice(1).map(decodeURIComponent);
-        const pathParams = _zipObject(paramKeys, paramsVals);
+        try {
+          const paramsVals = matchedRoute.slice(1).map(decodeURIComponent);
+          const pathParams = _zipObject(paramKeys, paramsVals);
 
-        const r = {
-          schema,
-          expressRoute,
-          openApiRoute,
-          pathParams,
-        };
-        (<any>r)._responseSchema = _schema;
-        return r;
+          const r = {
+            schema,
+            expressRoute,
+            openApiRoute,
+            pathParams,
+          };
+          (<any>r)._responseSchema = _schema;
+          return r;
+        } catch (error) {
+          throw new BadRequest({
+            path: req.path,
+            message: 'invalid URI',
+          })
+        }
       }
     }
 


### PR DESCRIPTION
I want to prevent bad data generated by a pen tester from causing a 500. For example, the following URL causes `decodeURIComponent` to throw a `URI malformed` error.

```
/accounts/%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%af%c0%ae%c0%ae%c0%afetc%c0%afpasswd
```

Instead I want to turn it into a `BadRequest` error. Does this seem good? Happy to add a test, but not sure where to put it?
