### PR TITLE
Make `type` property optional for `NonArraySchemaObject`

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -247,7 +247,7 @@ export namespace OpenAPIV3 {
   }
 
   export interface NonArraySchemaObject extends BaseSchemaObject {
-    type: NonArraySchemaObjectType;
+    type?: NonArraySchemaObjectType;
   }
 
   interface BaseSchemaObject {


### PR DESCRIPTION
#580 