### PR TITLE
Created issue_589 spec file and yaml

### DIFF
--- a/test/issue_589.spec.ts
+++ b/test/issue_589.spec.ts
@@ -1,0 +1,35 @@
+import * as path from 'path';
+import * as express from 'express';
+import * as request from 'supertest';
+import * as assert from 'assert';
+import { createApp } from './common/app';
+
+describe("DateFormats", () => {
+  let app = null;
+
+  before(async () => {
+    // Set up the express app
+    const apiSpec = path.join('test', 'resources', 'issue_589.yaml');
+    app = await createApp({ apiSpec }, 1996, (app) =>
+      app.use(
+        `${app.basePath}`,
+        express.Router().get(`/user`, (req, res) => res.json({id: 0, name: "Nick", date: new Date("1996-01-03T22:00:00.000Z")})),
+      ),
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should get the correct date', async () =>
+    request(app)
+      .get(`${app.basePath}/user`)
+      .expect(200).then((res)=>
+      {
+        assert.strictEqual(res.body.id, 0);
+        assert.strictEqual(res.body.name, "Nick"); 
+        assert.strictEqual(res.body.date, "1996-01-04"); 
+      })
+    );
+});

--- a/test/resources/issue_589.yaml
+++ b/test/resources/issue_589.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+servers:
+  # Added by API Auto Mocking Plugin
+  - description: SwaggerHub API Auto Mocking
+    url: https://virtserver.swaggerhub.com/babaliaris/test/1.0.0
+  - description: My Computer
+    url: http://localhost:1996
+  - description: Express Open Api Validator
+    url: /v1/
+info:
+  description: This is a simple API
+  version: "1.0.0"
+  title: Simple Inventory API
+  contact:
+    email: you@your-company.com
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+paths:
+  /user:
+    get:
+      tags:
+        - Users
+      summary: Get a user.
+      operationId: getUser
+
+      responses:
+        
+        '200':
+          description: Get the json user data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        default:
+          description: Something went wrong.
+
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - name
+        - date
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        date:
+          type: string
+          format: date


### PR DESCRIPTION
#589 
**This does not contain the fix yet, just a unit test to replicate the problem. In other words, the test should fail for now until the bug has been fixed.**

The problem should be [in this line](https://github.com/cdimascio/express-openapi-validator/blob/master/src/framework/base.serdes.ts#L16) but I wasn't able to replicate the problem in the project as I did in the distributed npm module (see #589 original post **Examples and context**).

I just created a simple test before trying to fix the bug and the result is this:
(Please note I'm in a Windows environment and I use ```npm run test:windows```)
```bash
 1) DateFormats
       should get the correct date:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ '1996-01-03T22:00:00.000Z'
- '1996-01-04'
            ^
      + expected - actual

      -1996-01-03T22:00:00.000Z
      +1996-01-04

      at A:\NodeProjects\express-openapi-validator\test\issue_589.spec.ts:32:16
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

The **+actual** in the assertion should be  **1996-01-03** (this is what I get while using the published npm version) and not **1996-01-03T22:00:00.000Z**
Even if I completely change the behavior of [this line](https://github.com/cdimascio/express-openapi-validator/blob/master/src/framework/base.serdes.ts#L16) the test result would still be the same which is weird.

Maybe it's not this line that causes the problem?

**Suggested Fix:**
```javascript
//d MUST be a Date Object.
const d = d.getTimezoneOffset();

//This will make sure to advance the day, month or year
//of a UTC time in such a way that the time part will be zero
//Example: "1996-01-03T22:00:00.000Z" ====> "1996-01-04T00:00:00.000Z"
d = new Date(yourDate.getTime() - (offset*60*1000));

//So now you can safely split using 'T' and keep the first part.
const correct_YYYY_MM_DD = d.toISOString().split('T')[0];
```