### PR TITLE
Validate no-content responses

### DIFF
--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -144,6 +144,19 @@ export class ResponseValidator {
       findResponseContent(accepts, validatorContentTypes) ||
       validatorContentTypes[0]; // take first contentType, if none found
 
+    if (validatorContentTypes.length === 0) {
+      // spec specifies no content for this response
+      if (body !== undefined) {
+        // response contains content/body
+        throw new InternalServerError({
+          path: '.response',
+          message: 'response should NOT have a body',
+        });
+      }
+      // response contains no content/body so OK
+      return;
+    }
+
     if (!contentType) {
       // not contentType inferred, assume valid
       console.warn('no contentType found');
@@ -275,6 +288,9 @@ export class ResponseValidator {
 
     const validators = {};
     for (const [code, contentTypeSchemas] of Object.entries(responseSchemas)) {
+      if (Object.keys(contentTypeSchemas).length === 0) {
+          validators[code] = {};
+      }
       for (const contentType of Object.keys(contentTypeSchemas)) {
         const schema = contentTypeSchemas[contentType];
         schema.paths = this.spec.paths; // add paths for resolution with multi-file

--- a/test/response.validation.spec.ts
+++ b/test/response.validation.spec.ts
@@ -29,7 +29,10 @@ describe(packageJson.name, () => {
           return res.json({ id: 213, name: 'name', kids: [] });
         });
         app.get(`${app.basePath}/empty_response`, (req, res) => {
-          return res.status(204).send();
+          if (req.query.mode === 'non_empty_response') {
+            return res.status(204).json({});
+          }
+          return res.status(204).json();
         });
         app.get(`${app.basePath}/boolean`, (req, res) => {
           return res.json(req.query.value);
@@ -173,6 +176,15 @@ describe(packageJson.name, () => {
       .expect(204)
       .then((r) => {
         expect(r.body).to.be.empty;
+      }));
+
+  it('should fail if response is not empty and an empty response is expected', async () =>
+    request(app)
+      .get(`${app.basePath}/empty_response?mode=non_empty_response`)
+      .expect(500)
+      .then((r) => {
+        expect(r.body.message).to.contain('response should NOT have a body');
+        expect(r.body).to.have.property('code').that.equals(500);
       }));
 
   it('should fail if additional properties are provided when set false', async () =>


### PR DESCRIPTION
Fail validation if the api spec specifiies that a response should be empty, but the implementation has returned a body.

Includes test to cover this scenario as well as minor change to 204 'No content' using 'json()' instead of 'send()' to improve code coverage rather than simply bypassing the validation

