### PR TITLE
Export OpenAPIV3 types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   Unauthorized,
   Forbidden,
 } from './framework/types';
+export { OpenAPIV3 } from "./framework/types"
 
 // export default openapiValidator;
 export const resolvers = res;


### PR DESCRIPTION
`apiSpec` arg of OpenApiValidator.middleware() type is also `OpenAPIV3.Document`, but it is not exported type.
I'd like to use `OpenAPIV3` document type on my application code as follows.
Would it be possible? Excuse me if there are any problems. 🙇 

```ts
// file1.ts
export const path1: OpenAPIV3.PathsObject = {
  "/v1/some1": {
    get: {
        // something
    }
  }
}
```
```ts
// file2.ts
export const path2: OpenAPIV3.PathsObject = {
  "/v1/some2": {
    post: {
        // something
    }
  }
}
```

```ts
// schema.ts
import { path1 } from "./file1";
import { path2 } from "./file2";

export const schema: OpenAPIV3.Document = {
  openapi: "3.0.3",
  info: {
    title: "some API",
    version: "1.0.0",
  },
  paths: deepmerge.all<OpenAPIV3.PathsObject>([path1, path2])
};
```