### PR TITLE
Add Path level query param to list ONLY if there is not already an operation-level query param by the same name.

### DIFF
--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -477,8 +477,11 @@ export class SchemaPreprocessor {
     if (v === parameters) return;
     v.parameters = v.parameters || [];
 
+    // Add Path level query param to list ONLY if there is not already an operation-level query param by the same name.
     for (const param of parameters) {
-      v.parameters.push(param);
+      if (!(v.parameters.some(vparam => vparam["name"] === param["name"]))){
+          v.parameters.push(param);
+      }
     }
   }
 


### PR DESCRIPTION
Addresses my concern in issue #626 , that query params described at the Path level are not being overidden by params described at the Operation level.... Instead, parameters are being validated against BOTH param descriptions.

Apologies, but I have not been able to test this myself, I don't have any typescript experience, and keep getting compilation errors (even before my change!). 

