### PR TITLE
Implement SerDes.jsonType option for non-object internal types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ To create custom serializers and/or deserializers, define:
 - `format` (required) - a custom 'unknown' format that triggers the serializer and/or deserializer
 - `deserialize` (optional) - upon receiving a request, transform a string property to an object. Deserialization occurs _after_ request schema validation.
 - `serialize` (optional) - before sending a response, transform an object to string. Serialization occurs _after_ response schema validation
+- `jsonType` (optional, default 'object') - set to override for deserialized types that are not 'object', eg 'array' 
 
 e.g.
 

--- a/src/framework/ajv/index.ts
+++ b/src/framework/ajv/index.ts
@@ -42,8 +42,19 @@ function createAjv(
         compile: (sch) => {
           if (sch) {
             return function validate(data, path, obj, propName) {
-              if (typeof data === 'object') return true;
-              if(!!sch.deserialize) {
+              if (!!sch.deserialize) {
+                if (typeof data !== 'string') {
+                  (<ajv.ValidateFunction>validate).errors = [
+                    {
+                      keyword: 'serdes',
+                      schemaPath: data,
+                      dataPath: path,
+                      message: `must be a string`,
+                      params: { 'x-eov-serdes': propName },
+                    },
+                  ];
+                  return false;
+                }
                 obj[propName] = sch.deserialize(data);
               }
               return true;
@@ -51,6 +62,7 @@ function createAjv(
           }
           return () => true;
         },
+        // errors: 'full',
       });
     }
     ajv.removeKeyword('readOnly');
@@ -86,7 +98,7 @@ function createAjv(
           if (sch) {
             return function validate(data, path, obj, propName) {
               if (typeof data === 'string') return true;
-              if(!!sch.serialize) {
+              if (!!sch.serialize) {
                 obj[propName] = sch.serialize(data);
               }
               return true;

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -72,6 +72,7 @@ export type Format = {
 
 export type SerDes = {
   format: string;
+  jsonType?: string;
   serialize?: (o: unknown) => string;
   deserialize?: (s: string) => unknown;
 };
@@ -80,24 +81,29 @@ export class SerDesSingleton implements SerDes {
   serializer: SerDes;
   deserializer: SerDes;
   format: string;
+  jsonType: string;
   serialize?: (o: unknown) => string;
   deserialize?: (s: string) => unknown;
 
   constructor(param: {
     format: string;
+    jsonType?: string;
     serialize: (o: unknown) => string;
     deserialize: (s: string) => unknown;
   }) {
     this.format = param.format;
+    this.jsonType = param.jsonType || 'object';
     this.serialize = param.serialize;
     this.deserialize = param.deserialize;
     this.deserializer = {
-      format : param.format,
-      deserialize : param.deserialize
+      format: param.format,
+      jsonType: param.jsonType || 'object',
+      deserialize: param.deserialize
     }
     this.serializer = {
-      format : param.format,
-      serialize : param.serialize
+      format: param.format,
+      jsonType: param.jsonType || 'object',
+      serialize: param.serialize
     }
   }
 };

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -352,7 +352,7 @@ export class SchemaPreprocessor {
       !!schema.format &&
       this.serDesMap[schema.format]
     ) {
-      (<any>schema).type = ['object', 'string'];
+      (<any>schema).type = [this.serDesMap[schema.format].jsonType || 'object', 'string'];
       schema['x-eov-serdes'] = this.serDesMap[schema.format];
     }
   }

--- a/test/resources/serdes.yaml
+++ b/test/resources/serdes.yaml
@@ -51,11 +51,16 @@ components:
     DateTime:
       type: string
       format: date-time
+    StringList:
+      type: string
+      format: string-list
     User:
       type: object
       properties:
         id:
           $ref: "#/components/schemas/ObjectId"
+        tags:
+          $ref: "#/components/schemas/StringList"
         creationDateTime:
           $ref: "#/components/schemas/DateTime"
         creationDate:

--- a/test/serdes.spec.ts
+++ b/test/serdes.spec.ts
@@ -416,7 +416,6 @@ describe('serdes with jsonType array type string-list', () => {
       .get(`${app.basePath}/users/5fdefd13a6640bb5fb5fa925`)
       .expect(200)
       .then((r) => {
-        debugger;
         expect(r.body.id).to.equal('5fdefd13a6640bb5fb5fa925');
         expect(r.body.creationDate).to.equal('2020-12-20');
         expect(r.body.creationDateTime).to.equal("2020-12-20T07:28:19.213Z");
@@ -471,6 +470,21 @@ describe('serdes with jsonType array type string-list', () => {
       .expect(400)
       .then((r) => {
         expect(r.body.message).to.equal('request.body.creationDate should match format "date"');
+      }));
+
+  it('should POST throw error for deserialize on request of non-string format', async () =>
+    request(app)
+      .post(`${app.basePath}/users`)
+      .send({
+        id: '5fdefd13a6640bb5fb5fa925',
+        tags: ['aa', 'bb', 'cc'],
+        creationDateTime: '2020-12-20T07:28:19.213Z',
+        creationDate: '2020-12-20'
+      })
+      .set('Content-Type', 'application/json')
+      .expect(400)
+      .then((r) => {
+        expect(r.body.message).to.equal('request.body.tags must be a string');
       }));
 
 });

--- a/test/serdes.spec.ts
+++ b/test/serdes.spec.ts
@@ -8,10 +8,10 @@ import { date, dateTime } from '../src/framework/base.serdes';
 const apiSpecPath = path.join('test', 'resources', 'serdes.yaml');
 
 class ObjectID {
-  id : string;
+  id: string;
 
   constructor(id: string = "5fdefd13a6640bb5fb5fa925") {
-    this.id= id;
+    this.id = id;
   }
 
   toString() {
@@ -49,28 +49,29 @@ describe('serdes', () => {
             serialize: (o) => o.toString(),
           },
         ],
+        unknownFormats: ['string-list'],
       },
       3005,
       (app) => {
         app.get([`${app.basePath}/users/:id?`], (req, res) => {
-          if(typeof req.params.id !== 'object') {
+          if (typeof req.params.id !== 'object') {
             throw new Error("Should be deserialized to ObjectId object");
           }
           let date = new Date("2020-12-20T07:28:19.213Z");
           res.json({
             id: req.params.id,
-            creationDateTime : date,
+            creationDateTime: date,
             creationDate: date
           });
         });
         app.post([`${app.basePath}/users`], (req, res) => {
-          if(typeof req.body.id !== 'object') {
+          if (typeof req.body.id !== 'object') {
             throw new Error("Should be deserialized to ObjectId object");
           }
-          if(typeof req.body.creationDate !== 'object' || !(req.body.creationDate instanceof Date)) {
+          if (typeof req.body.creationDate !== 'object' || !(req.body.creationDate instanceof Date)) {
             throw new Error("Should be deserialized to Date object");
           }
-          if(typeof req.body.creationDateTime !== 'object' || !(req.body.creationDateTime instanceof Date)) {
+          if (typeof req.body.creationDateTime !== 'object' || !(req.body.creationDateTime instanceof Date)) {
             throw new Error("Should be deserialized to Date object");
           }
           res.json(req.body);
@@ -115,7 +116,7 @@ describe('serdes', () => {
       .post(`${app.basePath}/users`)
       .send({
         id: '5fdefd13a6640bb5fb5fa925',
-        creationDateTime : '2020-12-20T07:28:19.213Z',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
         creationDate: '2020-12-20'
       })
       .set('Content-Type', 'application/json')
@@ -131,7 +132,7 @@ describe('serdes', () => {
       .post(`${app.basePath}/users`)
       .send({
         id: '5fdefd13a6640bb5fb5fa',
-        creationDateTime : '2020-12-20T07:28:19.213Z',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
         creationDate: '2020-12-20'
       })
       .set('Content-Type', 'application/json')
@@ -145,7 +146,7 @@ describe('serdes', () => {
       .post(`${app.basePath}/users`)
       .send({
         id: '5fdefd13a6640bb5fb5fa925',
-        creationDateTime : '2020-12-20T07:28:19.213Z',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
         creationDate: '2020-1f-20'
       })
       .set('Content-Type', 'application/json')
@@ -180,24 +181,24 @@ describe('serdes serialize response components only', () => {
             serialize: (o) => o.toString(),
           },
         ],
-        unknownFormats: ['mongo-objectid'],
+        unknownFormats: ['mongo-objectid', 'string-list'],
       },
       3005,
       (app) => {
         app.get([`${app.basePath}/users/:id?`], (req, res) => {
-          if(typeof req.params.id !== 'string') {
+          if (typeof req.params.id !== 'string') {
             throw new Error("Should be not be deserialized to ObjectId object");
           }
           let date = new Date("2020-12-20T07:28:19.213Z");
           let result = {
             id: new ObjectID(req.params.id),
-            creationDateTime : date,
-            creationDate : undefined,
+            creationDateTime: date,
+            creationDate: undefined,
           };
-          if(req.query.baddateresponse === 'functionNotExists') {
+          if (req.query.baddateresponse === 'functionNotExists') {
             result.creationDate = new ObjectID();
           }
-          else if(req.query.baddateresponse === 'functionBadFormat') {
+          else if (req.query.baddateresponse === 'functionBadFormat') {
             result.creationDate = new BadDate();
           }
           else {
@@ -206,13 +207,13 @@ describe('serdes serialize response components only', () => {
           res.json(result);
         });
         app.post([`${app.basePath}/users`], (req, res) => {
-          if(typeof req.body.id !== 'string') {
+          if (typeof req.body.id !== 'string') {
             throw new Error("Should NOT be deserialized to ObjectId object");
           }
-          if(typeof req.body.creationDate !== 'string') {
+          if (typeof req.body.creationDate !== 'string') {
             throw new Error("Should NTO be deserialized to Date object");
           }
-          if(typeof req.body.creationDateTime !== 'string') {
+          if (typeof req.body.creationDateTime !== 'string') {
             throw new Error("Should NOT be deserialized to Date object");
           }
           req.body.id = new ObjectID(req.body.id);
@@ -260,7 +261,7 @@ describe('serdes serialize response components only', () => {
       .post(`${app.basePath}/users`)
       .send({
         id: '5fdefd13a6640bb5fb5fa925',
-        creationDateTime : '2020-12-20T07:28:19.213Z',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
         creationDate: '2020-12-20'
       })
       .set('Content-Type', 'application/json')
@@ -276,7 +277,7 @@ describe('serdes serialize response components only', () => {
       .post(`${app.basePath}/users`)
       .send({
         id: '5fdefd13a6640bb5fb5fa',
-        creationDateTime : '2020-12-20T07:28:19.213Z',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
         creationDate: '2020-12-20'
       })
       .set('Content-Type', 'application/json')
@@ -290,7 +291,7 @@ describe('serdes serialize response components only', () => {
       .post(`${app.basePath}/users`)
       .send({
         id: '5fdefd13a6640bb5fb5fa925',
-        creationDateTime : '2020-12-20T07:28:19.213Z',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
         creationDate: '2020-1f-20'
       })
       .set('Content-Type', 'application/json')
@@ -302,7 +303,7 @@ describe('serdes serialize response components only', () => {
   it('should throw error 500 on invalid object type instead of Date expected', async () =>
     request(app)
       .get(`${app.basePath}/users/5fdefd13a6640bb5fb5fa925`)
-      .query({baddateresponse : 'functionNotExists'})
+      .query({ baddateresponse: 'functionNotExists' })
       .expect(500)
       .then((r) => {
         console.log(r);
@@ -312,7 +313,7 @@ describe('serdes serialize response components only', () => {
   /*
   FIXME Manage format validation after serialize ? I can serialize using a working serialize method but that respond a bad format
   it('should throw error 500 on an object that serialize to a bad string format', async () =>
-
+ 
     request(app)
       .get(`${app.basePath}/users/5fdefd13a6640bb5fb5fa925`)
       .query({baddateresponse : 'functionBadFormat'})
@@ -321,7 +322,157 @@ describe('serdes serialize response components only', () => {
         console.log(r.body);
         expect(r.body.message).to.equal('Something saying that date is not date-time format');
       }));
-
+ 
    */
 
 });
+
+describe('serdes with jsonType array type string-list', () => {
+  let app = null;
+
+  before(async () => {
+    // set up express app
+    app = await createApp(
+      {
+        apiSpec: apiSpecPath,
+        validateRequests: {
+          coerceTypes: true
+        },
+        validateResponses: {
+          coerceTypes: true
+        },
+        serDes: [
+          date,
+          dateTime,
+          {
+            format: "mongo-objectid",
+            deserialize: (s) => new ObjectID(s),
+            serialize: (o) => o.toString(),
+          },
+          {
+            format: 'string-list',
+            jsonType: 'array',
+            deserialize: (s): string[] => s.split(',').map(s => s.trim()),
+            serialize: (o): string => (o as string[]).join(','),
+          },
+        ],
+      },
+      3005,
+      (app) => {
+        app.get([`${app.basePath}/users/:id?`], (req, res) => {
+          if (typeof req.params.id !== 'object') {
+            throw new Error("Should be deserialized to ObjectId object");
+          }
+          let date = new Date("2020-12-20T07:28:19.213Z");
+          res.json({
+            id: req.params.id,
+            tags: ['aa', 'bb', 'cc'],
+            creationDateTime: date,
+            creationDate: date
+          });
+        });
+        app.post([`${app.basePath}/users`], (req, res) => {
+          if (typeof req.body.id !== 'object') {
+            throw new Error("Should be deserialized to ObjectId object");
+          }
+          if (!Array.isArray(req.body.tags)) {
+            throw new Error("Should be deserialized to an Array object");
+          }
+          if (typeof req.body.creationDate !== 'object' || !(req.body.creationDate instanceof Date)) {
+            throw new Error("Should be deserialized to Date object");
+          }
+          if (typeof req.body.creationDateTime !== 'object' || !(req.body.creationDateTime instanceof Date)) {
+            throw new Error("Should be deserialized to Date object");
+          }
+          res.json(req.body);
+        });
+        app.use((err, req, res, next) => {
+          console.error(err)
+          res.status(err.status ?? 500).json({
+            message: err.message,
+            code: err.status ?? 500,
+          });
+        });
+      },
+      false,
+    );
+    return app
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should control BAD id format and throw an error', async () =>
+    request(app)
+      .get(`${app.basePath}/users/1234`)
+      .expect(400)
+      .then((r) => {
+        expect(r.body.message).to.equal('request.params.id should match pattern "^[0-9a-fA-F]{24}$"');
+      }));
+
+  it('should control GOOD id format and get a response in expected format', async () => {
+    request(app)
+      .get(`${app.basePath}/users/5fdefd13a6640bb5fb5fa925`)
+      .expect(200)
+      .then((r) => {
+        debugger;
+        expect(r.body.id).to.equal('5fdefd13a6640bb5fb5fa925');
+        expect(r.body.creationDate).to.equal('2020-12-20');
+        expect(r.body.creationDateTime).to.equal("2020-12-20T07:28:19.213Z");
+        expect(r.body.tags).to.equal('aa,bb,cc');
+      })
+  });
+
+
+  it('should POST also works with deserialize on request then serialize en response', async () =>
+    request(app)
+      .post(`${app.basePath}/users`)
+      .send({
+        id: '5fdefd13a6640bb5fb5fa925',
+        tags: 'aa,bb,cc',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
+        creationDate: '2020-12-20'
+      })
+      .set('Content-Type', 'application/json')
+      .expect(200)
+      .then((r) => {
+        expect(r.body.id).to.equal('5fdefd13a6640bb5fb5fa925');
+        expect(r.body.creationDate).to.equal('2020-12-20');
+        expect(r.body.creationDateTime).to.equal("2020-12-20T07:28:19.213Z");
+        expect(r.body.tags).to.equal('aa,bb,cc');
+      }));
+
+  it('should POST throw error on invalid schema ObjectId', async () =>
+    request(app)
+      .post(`${app.basePath}/users`)
+      .send({
+        id: '5fdefd13a6640bb5fb5fa',
+        tags: 'aa,bb,cc',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
+        creationDate: '2020-12-20'
+      })
+      .set('Content-Type', 'application/json')
+      .expect(400)
+      .then((r) => {
+        expect(r.body.message).to.equal('request.body.id should match pattern "^[0-9a-fA-F]{24}$"');
+      }));
+
+  it('should POST throw error on invalid schema Date', async () =>
+    request(app)
+      .post(`${app.basePath}/users`)
+      .send({
+        id: '5fdefd13a6640bb5fb5fa925',
+        tags: 'aa,bb,cc',
+        creationDateTime: '2020-12-20T07:28:19.213Z',
+        creationDate: '2020-1f-20'
+      })
+      .set('Content-Type', 'application/json')
+      .expect(400)
+      .then((r) => {
+        expect(r.body.message).to.equal('request.body.creationDate should match format "date"');
+      }));
+
+});
+
+


### PR DESCRIPTION
The current SerDes assumes an object type on deserialization because the schema preprocessor hardcodes that jsonType. While arrays are objects in JS, they are distinct in JsonType so arrays will fail the object type check. 

This PR adds an option to specify an alternative like "array" jsonType and passes it through in the preprocessor code. Included are an added test and doc update.

Thanks for the work on this functionality @pilerou and @cdimascio.
