### PR TITLE
add option to ignore undocumented #577

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ OpenApiValidator.middleware({
   ],
   operationHandlers: false | 'operations/base/path' | { ... },
   ignorePaths: /.*\/pets$/,
+  ignoreUndocumented: false,
   fileUploader: { ... } | true | false,
   $refParser: {
     mode: 'bundle'
@@ -874,6 +875,12 @@ or as a function:
 ```
 ignorePaths: (path) => path.endsWith('/pets')
 ```
+
+### ▪️ ignoreUndocumented (optional)
+
+Disables any form of validation for requests which are not documented in the OpenAPI spec.
+
+Defaults to `false`
 
 ### ▪️ fileUploader (optional)
 

--- a/src/framework/openapi.context.ts
+++ b/src/framework/openapi.context.ts
@@ -10,14 +10,16 @@ export class OpenApiContext {
   public readonly expressRouteMap = {};
   public readonly openApiRouteMap = {};
   public readonly routes: RouteMetadata[] = [];
+  public readonly ignoreUndocumented: boolean;
   private readonly basePaths: string[];
   private readonly ignorePaths: RegExp | Function;
 
-  constructor(spec: Spec, ignorePaths: RegExp | Function) {
+  constructor(spec: Spec, ignorePaths: RegExp | Function, ignoreUndocumented: boolean = false) {
     this.apiDoc = spec.apiDoc;
     this.basePaths = spec.basePaths;
     this.routes = spec.routes;
     this.ignorePaths = ignorePaths;
+    this.ignoreUndocumented = ignoreUndocumented;
     this.buildRouteMaps(spec.routes);
   }
 

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -113,6 +113,7 @@ export interface OpenApiValidatorOpts {
   validateRequests?: boolean | ValidateRequestOpts;
   validateSecurity?: boolean | ValidateSecurityOpts;
   ignorePaths?: RegExp | Function;
+  ignoreUndocumented?: boolean;
   securityHandlers?: SecurityHandlers;
   coerceTypes?: boolean | 'array';
   unknownFormats?: true | string[] | 'ignore';

--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -29,6 +29,10 @@ export function applyOpenApiMetadata(
     if (matched) {
       const { expressRoute, openApiRoute, pathParams, schema } = matched;
       if (!schema) {
+        // Prevents validation for routes which match on path but mismatch on method
+        if(openApiContext.ignoreUndocumented) {
+          return next();
+        }
         throw new MethodNotAllowed({
           path: req.path,
           message: `${req.method} method not allowed`,
@@ -50,7 +54,7 @@ export function applyOpenApiMetadata(
         // add the response schema if validating responses
         (<any>req.openapi)._responseSchema = (<any>matched)._responseSchema;
       }
-    } else if (openApiContext.isManagedRoute(path)) {
+    } else if (openApiContext.isManagedRoute(path) && !openApiContext.ignoreUndocumented) {
       throw new NotFound({
         path: req.path,
         message: 'not found',

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -103,7 +103,7 @@ export class OpenApiValidator {
           resOpts,
         ).preProcess();
         return {
-          context: new OpenApiContext(spec, this.options.ignorePaths),
+          context: new OpenApiContext(spec, this.options.ignorePaths, this.options.ignoreUndocumented),
           responseApiDoc: sp.apiDocRes,
           error: null,
         };

--- a/test/577.spec.ts
+++ b/test/577.spec.ts
@@ -1,0 +1,71 @@
+import * as express from 'express';
+import { Server } from 'http';
+import * as request from 'supertest';
+import * as OpenApiValidator from '../src';
+import { OpenAPIV3 } from '../src/framework/types';
+import { startServer } from './common/app.common';
+import { deepStrictEqual } from 'assert';
+
+describe('#577 - Exclude response validation that is not in api spec', () => {
+  it('does not validate responses which are not present in the spec', async () => {
+    const apiSpec = createApiSpec();
+
+    const app = await createApp(apiSpec);
+    await request(app).get('/users').expect(200, 'some users');
+    await request(app).post('/users').expect(201, 'Created!');
+    await request(app).get ('/example').expect(200, 'Example indeed')
+    app.server.close();
+
+    deepStrictEqual(apiSpec, createApiSpec());
+  });
+});
+
+async function createApp(
+  apiSpec: OpenAPIV3.Document,
+): Promise<express.Express & { server?: Server }> {
+  const app = express();
+
+  app.use(
+    OpenApiValidator.middleware({
+      apiSpec,
+      validateRequests: true,
+      validateResponses: true,
+      ignoreUndocumented: true,
+    }),
+  );
+  app.get('/users', (req, res) => {
+      res.status(200).send('some users');
+    }
+  );
+  app.post('/users', (req, res) => {
+      res.status(201).send('Created!');
+    }
+  );
+
+  app.get('/example', (req, res) => {
+      res.status(200).send('Example indeed');
+    }
+  );
+
+  await startServer(app, 3001);
+  return app;
+}
+
+function createApiSpec(): OpenAPIV3.Document {
+  return {
+    openapi: '3.0.3',
+    info: {
+      title: 'Ping API',
+      version: '1.0.0',
+    },
+    paths: {
+      '/users': {
+        get: {
+          responses: {
+            '200': { description: 'pong!' },
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
Adds the `ignoreUndocumented` option as talked about in #577.

It bypasses both the 404 errors when calling routes that are not documented as well as the 405 errors when calling a route that is documented with a different method.

Feedback is very welcome 😄 