### PR TITLE
Export types from the package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export const error = {
 };
 
 export * as serdes from './framework/base.serdes';
+export * from './framework/types';
 
 function openapiValidator(options: OpenApiValidatorOpts) {
   const oav = new OpenApiValidator(options);


### PR DESCRIPTION
Currently I have to do this:

```ts
import type { OpenAPIV3 } from "express-openapi-validator/dist/framework/types";
```

Looking through the `framework/types.ts` file, it seems many of the types might be useful to users of the library, though I'm not sure if that's true of all of them.