### PR TITLE
Fix ajv logging warnings when discriminators are combined with $ref's

### DIFF
--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -315,10 +315,15 @@ export class SchemaPreprocessor {
 
       if (options.length > 0) {
         const newSchema = JSON.parse(JSON.stringify(schemaObj));
-        newSchema.properties = {
+
+        const newProperties = {
           ...(o.properties ?? {}),
           ...(newSchema.properties ?? {}),
         };
+        if(Object.keys(newProperties).length > 0) {
+          newSchema.properties = newProperties;
+        }
+
         newSchema.required = o.required;
         if (newSchema.required.length === 0) {
           delete newSchema.required;


### PR DESCRIPTION
This seems to be a bug when combining discriminators with references. In https://github.com/cdimascio/express-openapi-validator/blob/master/src/middlewares/parsers/schema.preprocessor.ts#L318 a `properties` field is added to the schema, even if empty. Then, ajv will detect that you have a object containing a $ref key along with an empty `properties` key, and trigger this piece of code that generates the said warning:
```
  if (it.schema.$ref && $refKeywords) {
    if (it.opts.extendRefs == 'fail') {
      throw new Error('$ref: validation keywords used in schema at path "' + it.errSchemaPath + '" (see option extendRefs)');
    } else if (it.opts.extendRefs !== true) {
      $refKeywords = false;
      it.logger.warn('$ref: keywords ignored in schema at path "' + it.errSchemaPath + '"');
    }
  }
```