### PR TITLE
if requestBody required is false, allow empty requests

### DIFF
--- a/src/middlewares/parsers/body.parse.ts
+++ b/src/middlewares/parsers/body.parse.ts
@@ -57,6 +57,9 @@ export class BodySchemaParser {
     }
 
     if (!content) {
+      if (requestBody.required === false) { // user has explicitly set body required to false
+        return {};
+      }
       const msg =
         contentType.contentType === 'not_provided'
           ? 'media type not specified'


### PR DESCRIPTION
Related issues:
https://github.com/cdimascio/express-openapi-validator/issues/646
https://github.com/cdimascio/express-openapi-validator/issues/655