### PR TITLE
#671 default export in handler

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -33,18 +33,16 @@ export function defaultResolver(
     const modulePath = path.join(handlersPath, baseName);
     if (!tmpModules[modulePath]) {
       tmpModules[modulePath] = require(modulePath);
-      if (!tmpModules[modulePath][oId]) {
-        // if oId is not found only module, try the module's default export
-        tmpModules[modulePath] = tmpModules[modulePath].default;
-      }
     }
-    if (!tmpModules[modulePath][oId]) {
+
+    const handler = tmpModules[modulePath][oId] || tmpModules[modulePath].default;
+
+    if (!handler) {
       throw Error(
-        `Could not find 'x-eov-operation-handler' with id ${oId} in module '${modulePath}'. Make sure operation '${oId}' defined in your API spec exists as a handler function in '${modulePath}'.`,
+        `Could not find 'x-eov-operation-handler' with id ${oId} in module '${modulePath}'. Make sure operation '${oId}' defined in your API spec exists as a handler function (or module has a default export) in '${modulePath}'.`,
       );
     }
 
-    const handler = tmpModules[modulePath][oId];
     cache[cacheKey] = handler;
     return handler;
   }

--- a/test/default-export.spec.ts
+++ b/test/default-export.spec.ts
@@ -1,0 +1,46 @@
+import * as express from 'express';
+import * as OpenApiValidator from '../src';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import * as path from 'path';
+
+describe('default export resolver', () => {
+  let server = null;
+  let app = express();
+
+  before(async () => {
+    app.use(
+      OpenApiValidator.middleware({
+        apiSpec: {
+          openapi: '3.0.0',
+          info: { version: '1.0.0', title: 'test bug OpenApiValidator' },
+          paths: {
+            '/': {
+              get: {
+                operationId: 'anything',
+                // @ts-ignore
+                'x-eov-operation-handler': 'controller-with-default',
+                responses: { 200: { description: 'home api' } }
+              }
+            },
+          },
+        },
+        operationHandlers: path.join(__dirname, 'resources'),
+      }),
+    );
+
+    server = app.listen(3000);
+    console.log('server start port 3000');
+  });
+
+  after(async () => server.close());
+
+  it('should use default export operation', async () => {
+    return request(app)
+      .get(`/`)
+      .expect(200)
+      .then((r) => {
+        expect(r.body).to.have.property('success').that.equals(true);
+      });
+  });
+});

--- a/test/resources/controller-with-default.ts
+++ b/test/resources/controller-with-default.ts
@@ -1,0 +1,3 @@
+export default function (req, res) {
+  res.json({success: true}).end();
+}


### PR DESCRIPTION
Hi,

issue #671 

I wasn't sure whether to add the `x-eov-operation-handler` optional property in `OperationObject` interface (since it has an important meaning in the program).

If you think it does not belong, we could instead use a `// @ts-ignore` comment in my new test before line 21.

Thanks