### PR TITLE
Run response validation middleware after operation handlers

### DIFF
--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -191,19 +191,6 @@ export class OpenApiValidator {
       });
     }
 
-    // response middleware
-    if (this.options.validateResponses) {
-      let resmw;
-      middlewares.push(function responseMiddleware(req, res, next) {
-        return pContext
-          .then(({ responseApiDoc }) => {
-            resmw = resmw || self.responseValidationMiddleware(responseApiDoc);
-            return resmw(req, res, next);
-          })
-          .catch(next);
-      })
-    }
-
     // op handler middleware
     if (this.options.operationHandlers) {
       let router: Router = null;
@@ -217,6 +204,19 @@ export class OpenApiValidator {
           .then((router) => router(req, res, next))
           .catch(next);
       });
+    }
+
+    // response middleware
+    if (this.options.validateResponses) {
+      let resmw;
+      middlewares.push(function responseMiddleware(req, res, next) {
+        return pContext
+          .then(({ responseApiDoc }) => {
+            resmw = resmw || self.responseValidationMiddleware(responseApiDoc);
+            return resmw(req, res, next);
+          })
+          .catch(next);
+      })
     }
 
     return middlewares;


### PR DESCRIPTION
Hey @cdimascio! I'm back again 😂 

💁‍♀️  This middleware orders the operation handlers middleware _before_ the response validation middleware.

I'm sure that 90% of the time, not many users would hit this issue but here's what it can look like (based on what I'm able to pick apart).

Consider we have the following JavaScript object:

```js
const user = {
  id: 343,

  toJSON() {
    return {
      id: `${this.id}`
    }
  }
}
```

In this example, I have "native" values stored on the object and am using the `toJSON` method to present this object in accordance with my OpenAPI specification which dictates that `user.id` MUST be a `string` (not a `number`).

When I have an operation handler that looks like the following, my expectation would be that the call to `res.json` would stringify the object and _THEN_ it would be passed to eov for response validation, when configured:

```js
exports.showUser = (req, res) => {
  const user = { /* ... */ }

  res.json(user)
}
```

However this fails validation with something like `.response.id expected to be a string`. It _SHOULD_ be a string! Now, if I call `toJSON` myself before calling `res.json` everything is great.

Upon further inspection, it looks like eov validates responses before the operation handler middleware has a chance to execute. My patch simply re-orders how these are attached to the Express application. After re-ordering, I no longer have to manually call `.toJSON()` on my objects before returning a JSON response.

If helpful, I can put together a more robust example project to demonstrate reproduction. Just let me know!