### PR TITLE
fix: ensure JSON in form-data field is parsed IFF it is an object or array

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -150,6 +150,11 @@ export class RequestValidator {
         body: req.body,
       };
       const schemaBody = <any>validator?.schemaBody;
+
+      if (contentType.mediaType === 'multipart/form-data') {
+        this.multipartNested(req, schemaBody);
+      }
+
       const discriminator = schemaBody?.properties?.body?._discriminator;
       const discriminatorValidator = this.discriminatorValidator(
         req,
@@ -180,6 +185,21 @@ export class RequestValidator {
         throw error;
       }
     };
+  }
+
+  private multipartNested(req, schemaBody) {
+    Object.keys(req.body).forEach((key) => {
+      const value = req.body[key];
+      const type = schemaBody?.properties?.body?.properties[key]?.type;
+      if (['array', 'object'].includes(type)) {
+        try {
+          req.body[key] = JSON.parse(value);
+        } catch (e) {
+          // NOOP
+        }
+      }
+    })
+    return null;
   }
 
   private discriminatorValidator(req, discriminator) {

--- a/test/common/test.yaml
+++ b/test/common/test.yaml
@@ -160,6 +160,13 @@ paths:
                   description: The photo
                   type: string
                   format: binary
+                array_with_objects:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      foo:
+                        type: string
         required: true
       responses:
         201:

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -127,11 +127,18 @@ describe('a multipart request', () => {
     });
 
     it('should validate multipart file and metadata', async () => {
+      const array_with_objects = JSON.stringify([
+        {
+          foo: 'bar'
+        }
+      ]);
+
       await request(app)
         .post(`${app.basePath}/sample_2`)
         .set('Content-Type', 'multipart/form-data')
         .set('Accept', 'application/json')
         .attach('file', 'package.json')
+        .field('array_with_objects', array_with_objects)
         .field('metadata', 'some-metadata')
         .expect(200)
         .then((r) => {


### PR DESCRIPTION
This commit fixes a problem with non primitives values in multipart/form-data field(s).