### PR TITLE
Export HTTPError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   NotFound,
   Unauthorized,
   Forbidden,
+  HTTPError,
 } from './framework/types';
 
 // export default openapiValidator;
@@ -27,6 +28,7 @@ export const error = {
   NotFound,
   Unauthorized,
   Forbidden,
+  HTTPError,
 };
 
 export * as serdes from './framework/base.serdes';


### PR DESCRIPTION
It's slightly more difficult than necessary to identity library-specific errors because the base class of all errors is not exported. Thus, `instanceof` has to be used for all error classes, or the base class recovered by reflection. In addition, the documentation should likely be changed to mention this if this proposal is suggested. I can make such modification on this branch if you wish, just reply below.

An alternative to exporting `HTTPError`, is possibly extending that from something akin to `ExpressOpenAPIValidatorError`, then exporting such a base class. That would resolve almost all naming conflicts that `HTTPError` would encounter (as it is a commonly repeated base class name in back-end node apps and libraries).

Thank all of you who have worked on the project thus-far; the library proves wildly useful for development.