### PR TITLE
Fix #604: Send custom objects to middleware from security validators

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -560,6 +560,14 @@ interface ErrorHeaders {
   Allow?: string;
 }
 
+export class CustomError extends Error {
+  error!: any;
+  constructor(error: any) {
+    super(error.message || "Custom Error");
+    this.error = error;
+  }
+}
+
 export class HttpError extends Error implements ValidationError {
   status!: number;
   path?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as res from './resolvers';
 import { OpenApiValidator, OpenApiValidatorOpts } from './openapi.validator';
 import { OpenApiSpecLoader } from './framework/openapi.spec.loader';
 import {
+  CustomError,
   InternalServerError,
   UnsupportedMediaType,
   RequestEntityTooLarge,
@@ -18,6 +19,7 @@ import {
 export const resolvers = res;
 export const middleware = openapiValidator;
 export const error = {
+  CustomError,
   InternalServerError,
   UnsupportedMediaType,
   RequestEntityTooLarge,

--- a/test/common/app.ts
+++ b/test/common/app.ts
@@ -8,6 +8,18 @@ import * as OpenApiValidator  from '../../src';
 import { startServer, routes } from './app.common';
 import { OpenApiValidatorOpts } from '../../src/framework/types';
 
+export class JsonResponse {
+  public status: number;
+  public message: string;
+  public data: any;
+
+  constructor(status: number, message: string, data: any) {
+    this.status = status;
+    this.message = message;
+    this.data = data;  
+  }
+}
+
 export async function createApp(
   opts?: OpenApiValidatorOpts,
   port = 3000,
@@ -30,6 +42,16 @@ export async function createApp(
   app.use(express.static(path.join(__dirname, 'public')));
 
   app.use(OpenApiValidator.middleware(opts));
+
+  // Add custom error handler
+  app.use((err, req, res, next) => {
+    if (err instanceof JsonResponse) {
+      res.status(err.status);
+      res.json(JSON.parse(JSON.stringify(err, null, 2)));
+    } else {
+      next(err);
+    }
+  });  
 
   if (useRoutes) {
     // register common routes


### PR DESCRIPTION
I was having the same issue where I wanted to send a custom error response format when encountering a 401 or 403 when validating tokens.

The solution that I went with was to create and export a CustomError class which people can instantiate and throw in their security handler callback functions.  The handler simply needs to create an instance of the CustomError with a payload that will be passed to the next express middleware method.

I'll also need to update the documentation for the security validator usage to showcase how a custom object can be returned.
https://github.com/cdimascio/express-openapi-validator/wiki/Documentation#security-handlers

See the test for an example of it's usage.