### PR TITLE
#627 Remove readOnly properties from request instead of throwing Bad Request errors

### DIFF
--- a/src/framework/ajv/index.ts
+++ b/src/framework/ajv/index.ts
@@ -104,23 +104,14 @@ function createAjv(
     ajv.removeKeyword('readOnly');
     ajv.addKeyword({
       keyword: 'readOnly',
+      modifying: true,
       errors: true,
       compile: (sch, p, it) => {
         if (sch) {
           const validate: DataValidateFunction = (data, ctx) => {
-            const isValid = data == null;
-            if (!isValid) {
-              validate.errors = [
-                {
-                  keyword: 'readOnly',
-                  instancePath: ctx.instancePath,
-                  schemaPath: it.schemaPath.str,
-                  message: `is read-only`,
-                  params: { writeOnly: ctx.parentDataProperty },
-                },
-              ];
-            }
-            return false;
+            // Remove readonly properties in request
+            delete ctx.parentData[ctx.parentDataProperty];
+            return true;
           };
           return validate;
         }

--- a/test/write.only.spec.ts
+++ b/test/write.only.spec.ts
@@ -42,7 +42,7 @@ describe(packageJson.name, () => {
     app.server.close();
   });
 
-  it('should not allow ready only inlined properties in requests', async () =>
+  it('should remove read only inlined properties in requests', async () =>
     request(app)
       .post(`${app.basePath}/products/inlined`)
       .set('content-type', 'application/json')
@@ -51,11 +51,12 @@ describe(packageJson.name, () => {
         price: 10.99,
         created_at: new Date().toUTCString(),
       })
-      .expect(400)
+      .expect(200)
       .then(r => {
         const body = r.body;
-        // id is a readonly property and should not be allowed in the request
-        expect(body.message).to.contain('created_at');
+        // created_at is a readonly property and should be removed form the request
+        expect(body.created_at).to.be.undefined;
+        expect(body.name).to.be.equal('some name');
       }));
 
   it('should not allow write only inlined properties in responses', async () =>
@@ -110,7 +111,7 @@ describe(packageJson.name, () => {
         expect(body.errors[0].message).to.contain('write-only');
       }));
 
-  it('should not allow read only properties in requests (deep nested schema $refs)', async () =>
+  it('should remove read only properties in requests (deep nested schema $refs)', async () =>
     request(app)
       .post(`${app.basePath}/products/nested`)
       .query({
@@ -128,9 +129,9 @@ describe(packageJson.name, () => {
           },
         ],
       })
-      .expect(400)
+      .expect(200)
       .then(r => {
         const body = r.body;
-        expect(body.message).to.contain('request/body/reviews/0/id');
+        expect(body.reviews[0].id).to.be.undefined;
       }));
 });


### PR DESCRIPTION
As discussed in #627 issue, whe should remove readonly data from request on validation.
Therefore, routes will receive a modified request wihtout readonly proprerties.

In this pull request :  
* AJV integration for readonly fields has been changed. In the same time,
* Unit tests has been modified according to the new mescanism