### PR TITLE
fixed router parameters

### DIFF
--- a/src/framework/openapi.spec.loader.ts
+++ b/src/framework/openapi.spec.loader.ts
@@ -64,7 +64,8 @@ export class OpenApiSpecLoader {
                 continue;
               }
               const pathParams = new Set<string>();
-              for (const param of schema.parameters ?? []) {
+              const parameters = [...schema.parameters ?? [], ...methods.parameters ?? []]
+              for (const param of parameters) {
                 if (param.in === 'path') {
                   pathParams.add(param.name);
                 }


### PR DESCRIPTION
Now router params are not parsed if parameters are described under **paths**: root, it works only for parameters under **method** block.

It should check both **paths** and **method** blocks