### PR TITLE
Remove examples from apiDoc when validating requests

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -42,6 +42,8 @@ export class RequestValidator {
   ) {
     this.middlewareCache = {};
     this.apiDoc = apiDoc;
+    // Examples not needed for validation
+    delete this.apiDoc.components.examples;
     this.requestOpts.allowUnknownQueryParameters =
       options.allowUnknownQueryParameters;
     this.ajv = createRequestAjv(apiDoc, { ...options, coerceTypes: true });


### PR DESCRIPTION
I'd like to remove the examples from the api doc in the request validator.  I don't think they're needed while validating the request.

This could be a way to bypass this weird bug: https://github.com/cdimascio/express-openapi-validator/issues/773