### PR TITLE
Rename field `error_code` to `errorCode` in `ValidationErrorItem`

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -558,7 +558,7 @@ export interface ValidationError {
 export interface ValidationErrorItem {
   path: string;
   message: string;
-  error_code?: string;
+  errorCode?: string;
 }
 
 interface ErrorHeaders {


### PR DESCRIPTION
This PR fixes #679. The field should be named `errorCode` as that's what is being used here: https://github.com/cdimascio/express-openapi-validator/blob/2b27332db20ed13d531ac420f4567c844c7c5a51/src/middlewares/util.ts#L89