### PR TITLE
Fix #821 issue - serDes field inside additionalProperties

### DIFF
--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -208,6 +208,9 @@ export class SchemaPreprocessor {
           const child = new Node(node, cschema, path);
           recurse(node, child, opts);
         });
+      } else if (schema.additionalProperties) {
+        const child = new Node(node, schema.additionalProperties, [...node.path, 'additionalProperties']);
+        recurse(node, child, opts);
       }
     };
 

--- a/test/821.spec.ts
+++ b/test/821.spec.ts
@@ -1,0 +1,68 @@
+import * as express from 'express';
+import { Server } from 'http';
+import * as request from 'supertest';
+import * as OpenApiValidator from '../src';
+import { OpenAPIV3 } from '../src/framework/types';
+import { startServer } from './common/app.common';
+import { deepStrictEqual } from 'assert';
+import * as path from 'path';
+
+
+const apiSpecPath = path.join('test', 'resources', '699.yaml');
+
+const date = new Date()
+describe('issue #821 - serialization inside addiotionalProperties', () => {
+  it('serializa both outer and inner date in addiotionalProperties', async () => {
+
+    const app = await createApp(apiSpecPath);
+    await request(app).get('/test').expect(200, 
+      {
+        outer_date: date.toISOString(),
+        other_info: {
+          something: {
+            inner_date: date.toISOString()
+          }
+        }
+      }      
+    );
+    app.server!.close();
+  });
+});
+
+async function createApp(
+  apiSpec: OpenAPIV3.Document | string,
+): Promise<express.Express & { server?: Server }> {
+  const app = express();
+
+  app.use(
+    OpenApiValidator.middleware({
+      apiSpec: apiSpecPath,
+      validateRequests: true,
+      validateResponses: true,
+    }),
+  );
+  app.get('/test', (req, res) => {
+    return res.status(200).json({
+      outer_date: date,
+      other_info: {
+        something: {
+          inner_date: date
+        }
+      }
+    })
+
+  })
+
+  app.use((err, req, res, next) => {
+    console.error(err); // dump error to console for debug
+    res.status(err.status || 500).json({
+      message: err.message,
+      errors: err.errors,
+    });
+  });
+
+  await startServer(app, 3001);
+  return app;
+}
+
+

--- a/test/resources/821.yaml
+++ b/test/resources/821.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: Test additionalProperties date-time
+paths:
+  /test:
+    get: 
+      responses:
+        '200':
+          description: foo
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  outer_date:
+                    type: string
+                    format: date-time
+                  other_info:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      properties:
+                        inner_date:
+                          type: string
+                          format: date-time


### PR DESCRIPTION
The problem was that the traverseSchemas function didn't explore the nodes inside `additionalProperties`. I added that case in the function and now it seems resolved.