### PR TITLE
fix: Deserialize custom types with inline schemas

### DIFF
--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -23,6 +23,7 @@ interface TraversalState {
 
 interface TopLevelPathNodes {
   requestBodies: Root<SchemaObject>[];
+  requestParameters: Root<SchemaObject>[];
   responses: Root<SchemaObject>[];
 }
 interface TopLevelSchemaNodes extends TopLevelPathNodes {
@@ -43,14 +44,31 @@ class Node<T, P> {
 }
 type SchemaObjectNode = Node<SchemaObject, SchemaObject>;
 
+function isParameterObject(node: ParameterObject | ReferenceObject): node is ParameterObject {
+  return !((node as ReferenceObject).$ref);
+}
+function isReferenceObject(node: ArraySchemaObject | NonArraySchemaObject | ReferenceObject): node is ReferenceObject {
+  return !!((node as ReferenceObject).$ref);
+}
+function isArraySchemaObject(node: ArraySchemaObject | NonArraySchemaObject | ReferenceObject): node is ArraySchemaObject {
+  return !!((node as ArraySchemaObject).items);
+}
+function isNonArraySchemaObject(node: ArraySchemaObject | NonArraySchemaObject | ReferenceObject): node is NonArraySchemaObject {
+  return !isArraySchemaObject(node) && !isReferenceObject(node);
+}
+
 class Root<T> extends Node<T, T> {
   constructor(schema: T, path: string[]) {
     super(null, schema, path);
   }
 }
 
-type SchemaObject = OpenAPIV3.SchemaObject;
+type ArraySchemaObject = OpenAPIV3.ArraySchemaObject;
+type NonArraySchemaObject = OpenAPIV3.NonArraySchemaObject;
+type OperationObject = OpenAPIV3.OperationObject;
+type ParameterObject = OpenAPIV3.ParameterObject;
 type ReferenceObject = OpenAPIV3.ReferenceObject;
+type SchemaObject = OpenAPIV3.SchemaObject;
 type Schema = ReferenceObject | SchemaObject;
 
 if (!Array.prototype['flatMap']) {
@@ -99,6 +117,7 @@ export class SchemaPreprocessor {
       schemas: componentSchemas,
       requestBodies: r.requestBodies,
       responses: r.responses,
+      requestParameters: r.requestParameters,
     };
 
     // Traverse the schemas
@@ -127,6 +146,7 @@ export class SchemaPreprocessor {
 
   private gatherSchemaNodesFromPaths(): TopLevelPathNodes {
     const requestBodySchemas = [];
+    const requestParameterSchemas = [];
     const responseSchemas = [];
 
     for (const [p, pi] of Object.entries(this.apiDoc.paths)) {
@@ -140,14 +160,18 @@ export class SchemaPreprocessor {
           const node = new Root<OpenAPIV3.OperationObject>(operation, path);
           const requestBodies = this.extractRequestBodySchemaNodes(node);
           const responseBodies = this.extractResponseSchemaNodes(node);
+          const requestParameters = this.extractRequestParameterSchemaNodes(node);
 
           requestBodySchemas.push(...requestBodies);
           responseSchemas.push(...responseBodies);
+          requestParameterSchemas.push(...requestParameters);
         }
       }
     }
+
     return {
       requestBodies: requestBodySchemas,
+      requestParameters: requestParameterSchemas,
       responses: responseSchemas,
     };
   }
@@ -225,6 +249,10 @@ export class SchemaPreprocessor {
     }
 
     for (const node of nodes.responses) {
+      recurse(null, node, initOpts());
+    }
+
+    for (const node of nodes.requestParameters) {
       recurse(null, node, initOpts());
     }
   }
@@ -502,6 +530,28 @@ export class SchemaPreprocessor {
     return schemas;
   }
 
+  private extractRequestParameterSchemaNodes(
+    operationNode: Root<OperationObject>,
+  ): Root<SchemaObject>[] {
+
+    return (operationNode.schema.parameters ?? []).flatMap((node) => {
+      const parameterObject = isParameterObject(node) ? node : undefined;
+      if (!parameterObject?.schema) return [];
+
+      const schema = isNonArraySchemaObject(parameterObject.schema) ?
+        parameterObject.schema :
+        undefined;
+      if (!schema) return [];
+
+      return new Root(schema, [
+        ...operationNode.path,
+        'parameters',
+        parameterObject.name,
+        parameterObject.in
+      ]);
+    });
+  }
+
   private resolveSchema<T>(schema): T {
     if (!schema) return null;
     const ref = schema?.['$ref'];
@@ -538,7 +588,7 @@ export class SchemaPreprocessor {
     ) =>
       // if name or ref exists and are equal
       (opParam['name'] && opParam['name'] === pathParam['name']) ||
-      (opParam['$ref'] && opParam['$ref'] === pathParam['$ref']);
+        (opParam['$ref'] && opParam['$ref'] === pathParam['$ref']);
 
     // Add Path level query param to list ONLY if there is not already an operation-level query param by the same name.
     for (const param of parameters) {

--- a/test/resources/serdes.yaml
+++ b/test/resources/serdes.yaml
@@ -13,6 +13,17 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/ObjectId"
+        - name: date-time-from-inline
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: date-time-from-schema
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/DateTime"
         - name: baddateresponse
           in: query
           schema:
@@ -29,21 +40,51 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                allOf:
+                  - $ref: "#/components/schemas/User"
+                  - type: object
+                    properties:
+                      summary:
+                        type: object
+                        additionalProperties:
+                          type: object
+                          properties:
+                            value:
+                              type: string
+                            typeof:
+                              type: string
   /users:
     post:
       requestBody:
         content :
           application/json:
             schema:
-              $ref: '#/components/schemas/User'
+              allOf:
+                - $ref: '#/components/schemas/User'
+                - type: object
+                  properties:
+                    creationDateTimeInline:
+                      type: string
+                      format: date-time
       responses:
         200:
           description: ""
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                allOf:
+                  - $ref: "#/components/schemas/User"
+                  - type: object
+                    properties:
+                      summary:
+                        type: object
+                        additionalProperties:
+                          type: object
+                          properties:
+                            value:
+                              type: string
+                            typeof:
+                              type: string
 components:
   schemas:
     ObjectId:


### PR DESCRIPTION
## 🐸  Problem to be solved
Inline schemas for custom formats in path parameters are not deserialized.

The following simple schema demonstrates the behavior:
* 🥇 `date-in-components` is deserialized to a `Date` object
* ⚠️ `date-inline` is *not* deserialized to a `Date` object

```yaml
paths:
  /users
    get:
      parameters:
        - name: date-in-components
          in: query
          schema:
            $ref: '#/components/schemas/DateTime'
        - name: date-inline
          in: query
          schema:
            type: string
            format: date-time
components:
  schemas:
    DateTime:
      type: string
      format: date-time
```

## 👑  Proposed solution
Gather path parameter custom-format schemas and augment them in the same way component schemas are.

## :wrench: Changes

- [x] serdes.spec app emits summary objects as part of its GET and POST responses
- [x] Type checks are made against response bodies (as well as existing checks in the endpoint handlers)
- [x] query parameters declared with inline custom format schemas are deserialized to their expected custom types