### PR TITLE
Fix #844 : fixing default export function issue

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -35,7 +35,7 @@ export function defaultResolver(
       tmpModules[modulePath] = require(modulePath);
     }
 
-    const handler = tmpModules[modulePath][oId] || tmpModules[modulePath].default;
+    const handler = tmpModules[modulePath][oId] || tmpModules[modulePath].default[oId] || tmpModules[modulePath].default;
 
     if (!handler) {
       throw Error(

--- a/test/default.export.fn.spec.ts
+++ b/test/default.export.fn.spec.ts
@@ -1,0 +1,46 @@
+import * as express from 'express';
+import * as OpenApiValidator from '../src';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import * as path from 'path';
+
+describe('default export resolver', () => {
+  let server = null;
+  let app = express();
+
+  before(async () => {
+    app.use(
+      OpenApiValidator.middleware({
+        apiSpec: {
+          openapi: '3.0.0',
+          info: { version: '1.0.0', title: 'test bug OpenApiValidator' },
+          paths: {
+            '/': {
+              get: {
+                operationId: 'test#get',
+                // @ts-ignore
+                'x-eov-operation-handler': 'routes/default-export-fn',
+                responses: { 200: { description: 'homepage' } }
+              }
+            },
+          },
+        },
+        operationHandlers: path.join(__dirname, 'resources'),
+      }),
+    );
+
+    server = app.listen(3000);
+    console.log('server start port 3000');
+  });
+
+  after(async () => server.close());
+
+  it('should use default export operation', async () => {
+    return request(app)
+      .get(`/`)
+      .expect(200)
+      .then((r) => {
+        expect(r.body).to.have.property('message').that.equals("It Works!");
+      });
+  });
+});

--- a/test/resources/routes/default-export-fn.js
+++ b/test/resources/routes/default-export-fn.js
@@ -1,0 +1,5 @@
+exports.default = {
+  'test#get': (req, res) => {
+    res.status(200).json({ message: 'It Works!' });
+  },
+};


### PR DESCRIPTION
This PR is to fix issue for `exports.default` functions which are part of operationId. 
Currently it gives error `Error: Route.get() requires a callback function but got a [object Object]` because its returning default response and not the one which is mentioned in operationId with `exports.default`

