### PR TITLE
Resolve "reference resolves to more than one schema" errors when AJV processes OpenAPI document and encounters unknown properties whose values include an `id` parameter.

### DIFF
--- a/test/ajv.resolves.more.than.one.schema.spec.ts
+++ b/test/ajv.resolves.more.than.one.schema.spec.ts
@@ -1,0 +1,98 @@
+import * as express from 'express';
+import { Server } from 'http';
+import * as request from 'supertest';
+import * as OpenApiValidator from '../src';
+import { OpenAPIV3 } from '../src/framework/types';
+import { startServer } from './common/app.common';
+import { deepStrictEqual } from 'assert';
+
+describe('AJV: reference resolves to more than one schema', () => {
+  it('it should ignore x-stoplight properties', async () => {
+    const apiSpec = createApiSpec();
+
+    const app = await createApp(apiSpec);
+
+    await request(app).get('/bear').expect(res => {
+      if (res.text.includes('resolves to more than one schema')) {
+        throw new Error('AJV not processing x-stoplight property correctly.')
+      }
+
+      if (!res.text.includes('Black Bear')) {
+        throw new Error()
+      }
+    })
+
+    app.server.close();
+
+    deepStrictEqual(apiSpec, createApiSpec());
+  });
+});
+
+async function createApp(
+  apiSpec: any,
+): Promise<express.Express & { server?: Server }> {
+  const app = express();
+
+  app.use(
+    OpenApiValidator.middleware({
+      apiSpec,
+      validateRequests: true,
+    }),
+  );
+  app.use(
+    express.Router().get('/bear', (req, res) => {
+      res.status(200).send({ type: 'Black Bear' });
+    }),
+  );
+
+  app.use((err, req, res, next) => {
+    res.status(500).send(err.stack)
+  })
+
+  await startServer(app, 3001);
+  return app;
+}
+
+function createApiSpec() {
+  return {
+    openapi: '3.0.3',
+    info: {
+      title: 'Bear API',
+      version: '1.0.0',
+    },
+    paths: {
+      '/bear': {
+        parameters: [],
+        get: {
+          responses: {
+            '200': { 
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Bear'
+                  }
+                }
+              }
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Bear: {
+          title: 'Bear',
+          'x-stoplight': {
+            id: 'ug68n9uynqll0'
+          },
+          properties: {
+            type: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  };
+}


### PR DESCRIPTION
Hello!

💁‍♂️ This PR addresses an issue with how AJV processes attributes that are outside of JSON Schema and are objects with an `id` parameter (which is treats as a special case).

**Background**

When someone uses [Stoplight Studio](https://stoplight.io/studio) to manage their OpenAPI specification, the editor injects `x-stoplight` attributes into various objects in order to create a link between the document and the editor. This `x-stoplight` attribute can look something like this:

```yaml
components:
  schemas:
    Bear:
      title: Bear
      x-stoplight:
        id: ug68n9uynqll0
      <snip>
```

Referencing this schema in an Operation causes the middleware to throw an exception from AJV that looks something like this:

```
Error: reference "ug68n9uynqll0" resolves to more than one schema
```

When you dig into AJV internals, you see that when AJV does not know about a particular OpenAPI specified property (beyond JSON Schema), it will treat `id` as a special case and does a validation step to make sure identifiers are not duplicated. [There are other examples of this happening](https://github.com/stoplightio/spectral/issues/2081) in Spectral where a user reports that duplicate `id` parameters in examples cause the same issue.

Their solution was to "de-examplify" the document before handing off to AJV; stripping examples from the document entirely for purposes of validation and error reporting in their tool.

**So I went about this the same way!**

This PR strips `x-stoplight` values from the `OpenAPIV3.Document` any time `createAjv` is used. Admittedly, this is fairly ham-handed and you may have a better way of getting AJV to "chill out". However, this does work as expected and I imagine for folks using Stoplight, alleviates a headache moving to 5.x+ of this package. 

Hehe, in fact, one of our projects is on the 4.x branch and I only became aware of this because two of my colleagues started a new project on 5.x, which upgrades AJV to 8.x. 