### PR TITLE
Normalize request body ContentTypes

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -67,7 +67,7 @@ export class RequestValidator {
     const reqSchema = openapi.schema;
     // cache middleware by combining method, path, and contentType
     const contentType = ContentType.from(req);
-    const contentTypeKey = contentType.equivalents()[0] ?? 'not_provided';
+    const contentTypeKey = contentType.normalize() ?? 'not_provided';
     // use openapi.expressRoute as path portion of key
     const key = `${req.method}-${path}-${contentTypeKey}`;
 

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -99,10 +99,7 @@ export class ResponseValidator {
   ): { [key: string]: ValidateFunction } {
     // get the request content type - used only to build the cache key
     const contentTypeMeta = ContentType.from(req);
-    const contentType =
-      (contentTypeMeta.contentType?.indexOf('multipart') > -1
-        ? contentTypeMeta.equivalents()[0]
-        : contentTypeMeta.contentType) ?? 'not_provided';
+    const contentType = contentTypeMeta.normalize() ?? 'not_provided';
 
     const openapi = <OpenApiRequestMetadata>req.openapi;
     const key = `${req.method}-${openapi.expressRoute}-${contentType}`;

--- a/test/common/app.common.ts
+++ b/test/common/app.common.ts
@@ -116,4 +116,14 @@ export function routes(app) {
       id: 'new-id',
     });
   });
+
+  app.post('/v1/pets_content_types', function(req: Request, res: Response): void {
+    // req.file is the `avatar` file
+    // req.body will hold the text fields, if there were any
+    res.json({
+      ...req.body,
+      contentType: req.headers['content-type'],
+      id: 'new-id',
+    });
+  });
 }

--- a/test/headers.spec.ts
+++ b/test/headers.spec.ts
@@ -70,5 +70,69 @@ describe(packageJson.name, () => {
           tag: 'cat',
         })
         .expect(200));
+
+    it('should succeed in sending a content-type: "application/json; version=1" in multiple ways', async () =>{
+      await request(app)
+        .post(`${app.basePath}/pets_content_types`)
+        .set('Content-Type', 'application/json; version=1')
+        .set('Accept', 'application/json')
+        .send({
+          name: 'myPet',
+          tag: 'cat',
+        })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.contentType).to.equal('application/json; version=1')
+        });
+
+      await request(app)
+        .post(`${app.basePath}/pets_content_types`)
+        .set('Content-Type', 'application/json;version=1')
+        .set('Accept', 'application/json')
+        .send({
+          name: 'myPet',
+          tag: 'cat',
+        })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.contentType).to.equal('application/json;version=1')
+        });
+    });
+        
+    it('should throw a 415 error for unsupported "application/json; version=2" content type', async () =>
+      request(app)
+        .post(`${app.basePath}/pets_content_types`)
+        .set('Content-Type', 'application/json; version=2')
+        .set('Accept', 'application/json')
+        .send({
+          name: 'myPet',
+          tag: 'cat',
+        })
+        .expect(415));
+
+    it('should throw a 415 error for a path/method which has previously succeeded using different request body content types', async () => {
+      await request(app)
+        .post(`${app.basePath}/pets_content_types`)
+        .set('Content-Type', 'application/json;version=1')
+        .set('Accept', 'application/json')
+        .send({
+          name: 'myPet',
+          tag: 'cat',
+        })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.contentType).to.equal('application/json;version=1')
+        });
+      
+      await request(app)
+        .post(`${app.basePath}/pets_content_types`)
+        .set('Content-Type', 'application/json; version=3')
+        .set('Accept', 'application/json')
+        .send({
+          name: 'myPet',
+          tag: 'cat',
+        })
+        .expect(415);
+    });
   });
 });

--- a/test/resources/openapi.yaml
+++ b/test/resources/openapi.yaml
@@ -362,6 +362,30 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: '#/components/schemas/Error'
+  /pets_content_types:
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json; version=1:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   parameters:


### PR DESCRIPTION
Fixes #862 

First I tackled ensuring that any ContentType type could be normalized so we could perform easy comparisons between what an HTTP request may send vs what the openapi document is expecting.  By normalizing as well, I was able to easily ensure that cache keys for validators don't have any conflicts.

Tests have been added to showcase the working solution.