### PR TITLE
Pass-through HttpError caught in multipart handler

### DIFF
--- a/src/middlewares/openapi.multipart.ts
+++ b/src/middlewares/openapi.multipart.ts
@@ -127,6 +127,8 @@ function error(req: OpenApiRequest, err: Error): ValidationError {
       : !unexpected
       ? new BadRequest({ path: req.path, message: err.message })
       : new InternalServerError({ path: req.path, message: err.message });*/
+  } else if (err instanceof HttpError) {
+    return err;
   } else {
     // HACK
     // TODO improve multer error handling


### PR DESCRIPTION
- Consumers of express-openapi-validator have access to the custom error types via exported object: [error](https://github.com/cdimascio/express-openapi-validator/blob/bb8d6b80c4bc42be9213d03c46b5d3f0195d1040/src/index.ts#L20-L30) (e.g. `error.BadRequest`).
- If the multipart handler throws, for example from the multer storage engine, check whether the `err` instance is already an `HttpError`. If so, it can be passed-through as is. This is mostly useful for setting the HTTP status code.