### PR TITLE
Safer handling of multipart nested JSON body props

### DIFF
--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -206,7 +206,8 @@ export class RequestValidator {
   private multipartNested(req, schemaBody) {
     Object.keys(req.body).forEach((key) => {
       const value = req.body[key];
-      const type = schemaBody?.properties?.body?.properties[key]?.type;
+      // TODO: Add support for oneOf, anyOf, allOf as the body schema
+      const type = schemaBody?.properties?.body?.properties?.[key]?.type;
       if (['array', 'object'].includes(type)) {
         try {
           req.body[key] = JSON.parse(value);
@@ -214,7 +215,7 @@ export class RequestValidator {
           // NOOP
         }
       }
-    })
+    });
     return null;
   }
 


### PR DESCRIPTION
If a multipart request body has schema oneOf, anyOf, or allOf, then automatic parsing of JSON properties throws. An object is expected. Fix the error today and add a TODO to add support for nested JSON props in multipart requests that utilize oneOf, anyOf, or allOf.

This issue was introduced in #730.

Fixes #875