### PR TITLE
feat(openapi): support OpenAPI version 3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "compile": "rimraf dist && tsc",
     "compile:release": "rimraf dist && tsc --sourceMap false",
-    "test": "mocha -r source-map-support/register -r ts-node/register --files --recursive -R spec test/**/*.spec.ts",
-    "test:debug": "mocha -r source-map-support/register -r ts-node/register --inspect-brk --files --recursive test/**/*.spec.ts",
-    "test:coverage": "nyc mocha -r source-map-support/register -r ts-node/register --recursive test/**/*.spec.ts",
+    "test": "mocha -r source-map-support/register -r ts-node/register --files --recursive -R spec --extension .spec.ts test",
+    "test:debug": "mocha -r source-map-support/register -r ts-node/register --inspect-brk --files --recursive --extension .spec.ts test",
+    "test:coverage": "nyc mocha -r source-map-support/register -r ts-node/register --recursive --extension .spec.ts test",
     "test:reset": "rimraf node_modules && npm i && npm run compile && npm t",
     "coveralls": "cat coverage/lcov.info | coveralls -v",
     "codacy": "bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage/lcov.info",

--- a/src/framework/ajv/index.ts
+++ b/src/framework/ajv/index.ts
@@ -11,21 +11,21 @@ interface SerDesSchema extends Partial<SerDes> {
 }
 
 export function createRequestAjv(
-  openApiSpec: OpenAPIV3.Document,
+  openApiSpec: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
   options: Options = {},
 ): AjvDraft4 {
   return createAjv(openApiSpec, options);
 }
 
 export function createResponseAjv(
-  openApiSpec: OpenAPIV3.Document,
+  openApiSpec: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
   options: Options = {},
 ): AjvDraft4 {
   return createAjv(openApiSpec, options, false);
 }
 
 function createAjv(
-  openApiSpec: OpenAPIV3.Document,
+  openApiSpec: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
   options: Options = {},
   request = true,
 ): AjvDraft4 {

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -75,7 +75,7 @@ export class OpenAPIFramework {
   private loadSpec(
     filePath: string | object,
     $refParser: { mode: 'bundle' | 'dereference' } = { mode: 'bundle' },
-  ): Promise<OpenAPIV3.Document> {
+  ): Promise<OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1> {
     // Because of this issue ( https://github.com/APIDevTools/json-schema-ref-parser/issues/101#issuecomment-421755168 )
     // We need this workaround ( use '$RefParser.dereference' instead of '$RefParser.bundle' ) if asked by user
     if (typeof filePath === 'string') {
@@ -87,7 +87,7 @@ export class OpenAPIFramework {
           $refParser.mode === 'dereference'
             ? $RefParser.dereference(absolutePath)
             : $RefParser.bundle(absolutePath);
-        return doc as Promise<OpenAPIV3.Document>;
+        return doc as Promise<OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1>;
       } else {
         throw new Error(
           `${this.loggingPrefix}spec could not be read at ${filePath}`,
@@ -98,10 +98,10 @@ export class OpenAPIFramework {
       $refParser.mode === 'dereference'
         ? $RefParser.dereference(filePath)
         : $RefParser.bundle(filePath);
-    return doc as Promise<OpenAPIV3.Document>;
+    return doc as Promise<OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1>;
   }
 
-  private sortApiDocTags(apiDoc: OpenAPIV3.Document): void {
+  private sortApiDocTags(apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1): void {
     if (apiDoc && Array.isArray(apiDoc.tags)) {
       apiDoc.tags.sort((a, b): number => {
         return a.name < b.name ? -1 : 1;

--- a/src/framework/openapi.context.ts
+++ b/src/framework/openapi.context.ts
@@ -6,7 +6,7 @@ export interface RoutePair {
   openApiRoute: string;
 }
 export class OpenApiContext {
-  public readonly apiDoc: OpenAPIV3.Document;
+  public readonly apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
   public readonly expressRouteMap = {};
   public readonly openApiRouteMap = {};
   public readonly routes: RouteMetadata[] = [];

--- a/src/framework/openapi.schema.validator.ts
+++ b/src/framework/openapi.schema.validator.ts
@@ -56,7 +56,7 @@ export class OpenAPISchemaValidator {
     this.validator = ajvInstance.compile(schema);
   }
 
-  public validate(openapiDoc: OpenAPIV3.Document): {
+  public validate(openapiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1): {
     errors: Array<ErrorObject> | null;
   } {
     const valid = this.validator(openapiDoc);

--- a/src/framework/openapi.schema.validator.ts
+++ b/src/framework/openapi.schema.validator.ts
@@ -6,7 +6,11 @@ import AjvDraft4, {
 import addFormats from 'ajv-formats';
 // https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v3.0/schema.json
 import * as openapi3Schema from './openapi.v3.schema.json';
+// https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v3.1/schema.json with dynamic refs replaced due to AJV bug - https://github.com/ajv-validator/ajv/issues/1745
+import * as openapi31Schema from './openapi.v3_1.modified.schema.json';
 import { OpenAPIV3 } from './types.js';
+
+import Ajv2020 from 'ajv/dist/2020';
 
 export interface OpenAPISchemaValidatorOpts {
   version: string;
@@ -17,7 +21,6 @@ export class OpenAPISchemaValidator {
   private validator: ValidateFunction;
   constructor(opts: OpenAPISchemaValidatorOpts) {
     const options: Options = {
-      schemaId: 'id',
       allErrors: true,
       validateFormats: true,
       coerceTypes: false,
@@ -29,15 +32,28 @@ export class OpenAPISchemaValidator {
       options.validateSchema = false;
     }
 
-    const v = new AjvDraft4(options);
-    addFormats(v, ['email', 'regex', 'uri', 'uri-reference']);
-
-    const ver = opts.version && parseInt(String(opts.version), 10);
+    const ver = opts.version && parseFloat(String(opts.version));
     if (!ver) throw Error('version missing from OpenAPI specification');
-    if (ver != 3) throw Error('OpenAPI v3 specification version is required');
+    if (parseInt(ver.toString()) != 3) throw Error('OpenAPI v3 specification version is required');
 
-    v.addSchema(openapi3Schema);
-    this.validator = v.compile(openapi3Schema);
+    let ajvInstance;
+    let schema;
+
+    if (ver === 3) {
+      schema = openapi3Schema;
+      ajvInstance = new AjvDraft4(options);
+    } else if (ver === 3.1) {
+      schema = openapi31Schema;
+      ajvInstance = new Ajv2020(options);
+      ajvInstance.addFormat('media-range', true); // TODO: Validate media-range format as defined in https://www.rfc-editor.org/rfc/rfc9110.html#name-collected-abnf
+    } else {
+      throw new Error('OpenAPI v3 specification 3.0 and 3.1 supported');
+    }
+
+    addFormats(ajvInstance, ['email', 'regex', 'uri', 'uri-reference']);
+
+    ajvInstance.addSchema(schema);
+    this.validator = ajvInstance.compile(schema);
   }
 
   public validate(openapiDoc: OpenAPIV3.Document): {

--- a/src/framework/openapi.schema.validator.ts
+++ b/src/framework/openapi.schema.validator.ts
@@ -32,22 +32,26 @@ export class OpenAPISchemaValidator {
       options.validateSchema = false;
     }
 
-    const ver = opts.version && parseFloat(String(opts.version));
-    if (!ver) throw Error('version missing from OpenAPI specification');
-    if (parseInt(ver.toString()) != 3) throw Error('OpenAPI v3 specification version is required');
+    const [ok, major, minor] = /^(\d+)\.(\d+).(\d+)?$/.exec(opts.version);
+
+    if (!ok) { 
+      throw Error('Version missing from OpenAPI specification')
+    };
+
+    if (major !== '3' || minor !== '0' && minor !== '1') {
+      throw new Error('OpenAPI v3.0 or v3.1 specification version is required');
+    }
 
     let ajvInstance;
     let schema;
 
-    if (ver === 3) {
+    if (minor === '0') {
       schema = openapi3Schema;
       ajvInstance = new AjvDraft4(options);
-    } else if (ver === 3.1) {
+    } else if (minor == '1') {
       schema = openapi31Schema;
       ajvInstance = new Ajv2020(options);
       ajvInstance.addFormat('media-range', true); // TODO: Validate media-range format as defined in https://www.rfc-editor.org/rfc/rfc9110.html#name-collected-abnf
-    } else {
-      throw new Error('OpenAPI v3 specification 3.0 and 3.1 supported');
     }
 
     addFormats(ajvInstance, ['email', 'regex', 'uri', 'uri-reference']);

--- a/src/framework/openapi.schema.validator.ts
+++ b/src/framework/openapi.schema.validator.ts
@@ -51,7 +51,12 @@ export class OpenAPISchemaValidator {
     } else if (minor == '1') {
       schema = openapi31Schema;
       ajvInstance = new Ajv2020(options);
-      ajvInstance.addFormat('media-range', true); // TODO: Validate media-range format as defined in https://www.rfc-editor.org/rfc/rfc9110.html#name-collected-abnf
+    
+      // Open API 3.1 has a custom "media-range" attribute defined in its schema, but the spec does not define it. "It's not really intended to be validated"
+      // https://github.com/OAI/OpenAPI-Specification/issues/2714#issuecomment-923185689
+      // Since the schema is non-normative (https://github.com/OAI/OpenAPI-Specification/pull/3355#issuecomment-1915695294) we will only validate that it's a string
+      // as the spec states
+      ajvInstance.addFormat('media-range', true);
     }
 
     addFormats(ajvInstance, ['email', 'regex', 'uri', 'uri-reference']);

--- a/src/framework/openapi.v3_1.modified.schema.json
+++ b/src/framework/openapi.v3_1.modified.schema.json
@@ -1,0 +1,1407 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.1.x documents without schema validation, as defined by https://spec.openapis.org/oas/v3.1.0",
+  "type": "object",
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.1\\.\\d+(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "jsonSchemaDialect": {
+      "type": "string",
+      "format": "uri",
+      "default": "https://spec.openapis.org/oas/3.1/dialect/base"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/server"
+      },
+      "default": [{
+        "url": "/"
+      }]
+    },
+    "paths": {
+      "$ref": "#/$defs/paths"
+    },
+    "webhooks": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item-or-reference"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/security-requirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tag"
+      }
+    },
+    "externalDocs": {
+      "$ref": "#/$defs/external-documentation"
+    }
+  },
+  "required": [
+    "openapi",
+    "info"
+  ],
+  "anyOf": [{
+      "required": [
+        "paths"
+      ]
+    },
+    {
+      "required": [
+        "components"
+      ]
+    },
+    {
+      "required": [
+        "webhooks"
+      ]
+    }
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#info-object",
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri"
+        },
+        "contact": {
+          "$ref": "#/$defs/contact"
+        },
+        "license": {
+          "$ref": "#/$defs/license"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "contact": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#contact-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "license": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#license-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#server-object",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/server-variable"
+          }
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server-variable": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#server-variable-object",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "components": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#components-object",
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/schema"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/response-or-reference"
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/request-body-or-reference"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/security-scheme-or-reference"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "pathItems": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/path-item-or-reference"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems)$": {
+          "$comment": "Enumerating all of the property names in the regex above is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "paths": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#paths-object",
+      "type": "object",
+      "patternProperties": {
+        "^/": {
+          "$ref": "#/$defs/path-item"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#path-item-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "get": {
+          "$ref": "#/$defs/operation"
+        },
+        "put": {
+          "$ref": "#/$defs/operation"
+        },
+        "post": {
+          "$ref": "#/$defs/operation"
+        },
+        "delete": {
+          "$ref": "#/$defs/operation"
+        },
+        "options": {
+          "$ref": "#/$defs/operation"
+        },
+        "head": {
+          "$ref": "#/$defs/operation"
+        },
+        "patch": {
+          "$ref": "#/$defs/operation"
+        },
+        "trace": {
+          "$ref": "#/$defs/operation"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "operation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#operation-object",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-or-reference"
+        },
+        "responses": {
+          "$ref": "#/$defs/responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/security-requirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "external-documentation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#external-documentation-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#parameter-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "enum": [
+            "query",
+            "header",
+            "path",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$ref": "#/$defs/schema"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "required": [
+        "name",
+        "in"
+      ],
+      "oneOf": [{
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "if": {
+        "properties": {
+          "in": {
+            "const": "query"
+          }
+        },
+        "required": [
+          "in"
+        ]
+      },
+      "then": {
+        "properties": {
+          "allowEmptyValue": {
+            "default": false,
+            "type": "boolean"
+          }
+        }
+      },
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "explode": {
+              "type": "boolean"
+            }
+          },
+          "allOf": [{
+              "$ref": "#/$defs/examples"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-cookie"
+            },
+            {
+              "$ref": "#/$defs/styles-for-form"
+            }
+          ],
+          "$defs": {
+            "styles-for-path": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "path"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "enum": [
+                      "matrix",
+                      "label",
+                      "simple"
+                    ]
+                  },
+                  "required": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            },
+            "styles-for-header": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "header"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "const": "simple"
+                  }
+                }
+              }
+            },
+            "styles-for-query": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "query"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "enum": [
+                      "form",
+                      "spaceDelimited",
+                      "pipeDelimited",
+                      "deepObject"
+                    ]
+                  },
+                  "allowReserved": {
+                    "default": false,
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "styles-for-cookie": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "cookie"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "const": "form"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/parameter"
+      }
+    },
+    "request-body": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#request-body-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/request-body"
+      }
+    },
+    "content": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#fixed-fields-10",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/media-type"
+      },
+      "propertyNames": {
+        "format": "media-range"
+      }
+    },
+    "media-type": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#media-type-object",
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/$defs/schema"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/encoding"
+          }
+        }
+      },
+      "allOf": [{
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/examples"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "encoding": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#encoding-object",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "format": "media-range"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "style": {
+          "default": "form",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "allOf": [{
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/styles-for-form"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "responses": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#responses-object",
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:[0-9]{2}|XX)$": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "minProperties": 1,
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "if": {
+        "$comment": "either default, or at least one response code property must exist",
+        "patternProperties": {
+          "^[1-5](?:[0-9]{2}|XX)$": false
+        }
+      },
+      "then": {
+        "required": ["default"]
+      }
+    },
+    "response": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#response-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/response"
+      }
+    },
+    "callbacks": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#callback-object",
+      "type": "object",
+      "$ref": "#/$defs/specification-extensions",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item-or-reference"
+      }
+    },
+    "callbacks-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/callbacks"
+      }
+    },
+    "example": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#example-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": true,
+        "externalValue": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "not": {
+        "required": [
+          "value",
+          "externalValue"
+        ]
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "example-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/example"
+      }
+    },
+    "link": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#link-object",
+      "type": "object",
+      "properties": {
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/map-of-strings"
+        },
+        "requestBody": true,
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "#/$defs/server"
+        }
+      },
+      "oneOf": [{
+          "required": [
+            "operationRef"
+          ]
+        },
+        {
+          "required": [
+            "operationId"
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "link-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "header": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#header-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$ref": "#/$defs/schema"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "oneOf": [{
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "default": "simple",
+              "const": "simple"
+            },
+            "explode": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "$ref": "#/$defs/examples"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "header-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/header"
+      }
+    },
+    "tag": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#tag-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reference": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#reference-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#schema-object",
+      "$dynamicAnchor": "meta",
+      "type": [
+        "object",
+        "boolean"
+      ]
+    },
+    "security-scheme": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#security-scheme-object",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "apiKey",
+            "http",
+            "mutualTLS",
+            "oauth2",
+            "openIdConnect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "allOf": [{
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-apikey"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http-bearer"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oauth2"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oidc"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "type-apikey": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "apiKey"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "in": {
+                "enum": [
+                  "query",
+                  "header",
+                  "cookie"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "in"
+            ]
+          }
+        },
+        "type-http": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "scheme": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ]
+          }
+        },
+        "type-http-bearer": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              },
+              "scheme": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ]
+          },
+          "then": {
+            "properties": {
+              "bearerFormat": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "type-oauth2": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oauth2"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "flows": {
+                "$ref": "#/$defs/oauth-flows"
+              }
+            },
+            "required": [
+              "flows"
+            ]
+          }
+        },
+        "type-oidc": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openIdConnect"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "openIdConnectUrl": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": [
+              "openIdConnectUrl"
+            ]
+          }
+        }
+      }
+    },
+    "security-scheme-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/security-scheme"
+      }
+    },
+    "oauth-flows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/$defs/oauth-flows/$defs/implicit"
+        },
+        "password": {
+          "$ref": "#/$defs/oauth-flows/$defs/password"
+        },
+        "clientCredentials": {
+          "$ref": "#/$defs/oauth-flows/$defs/client-credentials"
+        },
+        "authorizationCode": {
+          "$ref": "#/$defs/oauth-flows/$defs/authorization-code"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "$defs": {
+        "implicit": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "password": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "client-credentials": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "authorization-code": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "security-requirement": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#security-requirement-object",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/oas/v3.1.0#specification-extensions",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "examples": {
+      "properties": {
+        "example": true,
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        }
+      }
+    },
+    "map-of-strings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "styles-for-form": {
+      "if": {
+        "properties": {
+          "style": {
+            "const": "form"
+          }
+        },
+        "required": [
+          "style"
+        ]
+      },
+      "then": {
+        "properties": {
+          "explode": {
+            "default": true
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "explode": {
+            "default": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/framework/openapi.v3_1.modified.schema.json
+++ b/src/framework/openapi.v3_1.modified.schema.json
@@ -21,9 +21,11 @@
       "items": {
         "$ref": "#/$defs/server"
       },
-      "default": [{
-        "url": "/"
-      }]
+      "default": [
+        {
+          "url": "/"
+        }
+      ]
     },
     "paths": {
       "$ref": "#/$defs/paths"
@@ -31,7 +33,7 @@
     "webhooks": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/path-item-or-reference"
+        "$ref": "#/$defs/path-item"
       }
     },
     "components": {
@@ -53,24 +55,16 @@
       "$ref": "#/$defs/external-documentation"
     }
   },
-  "required": [
-    "openapi",
-    "info"
-  ],
-  "anyOf": [{
-      "required": [
-        "paths"
-      ]
+  "required": ["openapi", "info"],
+  "anyOf": [
+    {
+      "required": ["paths"]
     },
     {
-      "required": [
-        "components"
-      ]
+      "required": ["components"]
     },
     {
-      "required": [
-        "webhooks"
-      ]
+      "required": ["webhooks"]
     }
   ],
   "$ref": "#/$defs/specification-extensions",
@@ -103,10 +97,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "title",
-        "version"
-      ],
+      "required": ["title", "version"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -144,15 +135,11 @@
           "format": "uri"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "dependentSchemas": {
         "identifier": {
           "not": {
-            "required": [
-              "url"
-            ]
+            "required": ["url"]
           }
         }
       },
@@ -164,8 +151,7 @@
       "type": "object",
       "properties": {
         "url": {
-          "type": "string",
-          "format": "uri-reference"
+          "type": "string"
         },
         "description": {
           "type": "string"
@@ -177,9 +163,7 @@
           }
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -201,9 +185,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "default"
-      ],
+      "required": ["default"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -268,7 +250,7 @@
         "pathItems": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/path-item-or-reference"
+            "$ref": "#/$defs/path-item"
           }
         }
       },
@@ -298,6 +280,10 @@
       "$comment": "https://spec.openapis.org/oas/v3.1.0#path-item-object",
       "type": "object",
       "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
         "summary": {
           "type": "string"
         },
@@ -343,20 +329,6 @@
       },
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
-    },
-    "path-item-or-reference": {
-      "if": {
-        "type": "object",
-        "required": [
-          "$ref"
-        ]
-      },
-      "then": {
-        "$ref": "#/$defs/reference"
-      },
-      "else": {
-        "$ref": "#/$defs/path-item"
-      }
     },
     "operation": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#operation-object",
@@ -430,9 +402,7 @@
           "format": "uri"
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -444,12 +414,7 @@
           "type": "string"
         },
         "in": {
-          "enum": [
-            "query",
-            "header",
-            "path",
-            "cookie"
-          ]
+          "enum": ["query", "header", "path", "cookie"]
         },
         "description": {
           "type": "string"
@@ -471,19 +436,13 @@
           "maxProperties": 1
         }
       },
-      "required": [
-        "name",
-        "in"
-      ],
-      "oneOf": [{
-          "required": [
-            "schema"
-          ]
+      "required": ["name", "in"],
+      "oneOf": [
+        {
+          "required": ["schema"]
         },
         {
-          "required": [
-            "content"
-          ]
+          "required": ["content"]
         }
       ],
       "if": {
@@ -492,9 +451,7 @@
             "const": "query"
           }
         },
-        "required": [
-          "in"
-        ]
+        "required": ["in"]
       },
       "then": {
         "properties": {
@@ -514,7 +471,8 @@
               "type": "boolean"
             }
           },
-          "allOf": [{
+          "allOf": [
+            {
               "$ref": "#/$defs/examples"
             },
             {
@@ -541,27 +499,19 @@
                     "const": "path"
                   }
                 },
-                "required": [
-                  "in"
-                ]
+                "required": ["in"]
               },
               "then": {
                 "properties": {
                   "style": {
                     "default": "simple",
-                    "enum": [
-                      "matrix",
-                      "label",
-                      "simple"
-                    ]
+                    "enum": ["matrix", "label", "simple"]
                   },
                   "required": {
                     "const": true
                   }
                 },
-                "required": [
-                  "required"
-                ]
+                "required": ["required"]
               }
             },
             "styles-for-header": {
@@ -571,9 +521,7 @@
                     "const": "header"
                   }
                 },
-                "required": [
-                  "in"
-                ]
+                "required": ["in"]
               },
               "then": {
                 "properties": {
@@ -591,9 +539,7 @@
                     "const": "query"
                   }
                 },
-                "required": [
-                  "in"
-                ]
+                "required": ["in"]
               },
               "then": {
                 "properties": {
@@ -620,9 +566,7 @@
                     "const": "cookie"
                   }
                 },
-                "required": [
-                  "in"
-                ]
+                "required": ["in"]
               },
               "then": {
                 "properties": {
@@ -642,9 +586,7 @@
     "parameter-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -668,18 +610,14 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "content"
-      ],
+      "required": ["content"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
     "request-body-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -712,7 +650,8 @@
           }
         }
       },
-      "allOf": [{
+      "allOf": [
+        {
           "$ref": "#/$defs/specification-extensions"
         },
         {
@@ -737,12 +676,7 @@
         },
         "style": {
           "default": "form",
-          "enum": [
-            "form",
-            "spaceDelimited",
-            "pipeDelimited",
-            "deepObject"
-          ]
+          "enum": ["form", "spaceDelimited", "pipeDelimited", "deepObject"]
         },
         "explode": {
           "type": "boolean"
@@ -752,7 +686,8 @@
           "type": "boolean"
         }
       },
-      "allOf": [{
+      "allOf": [
+        {
           "$ref": "#/$defs/specification-extensions"
         },
         {
@@ -810,18 +745,14 @@
           }
         }
       },
-      "required": [
-        "description"
-      ],
+      "required": ["description"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
     "response-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -835,15 +766,13 @@
       "type": "object",
       "$ref": "#/$defs/specification-extensions",
       "additionalProperties": {
-        "$ref": "#/$defs/path-item-or-reference"
+        "$ref": "#/$defs/path-item"
       }
     },
     "callbacks-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -869,10 +798,7 @@
         }
       },
       "not": {
-        "required": [
-          "value",
-          "externalValue"
-        ]
+        "required": ["value", "externalValue"]
       },
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
@@ -880,9 +806,7 @@
     "example-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -913,15 +837,12 @@
           "$ref": "#/$defs/server"
         }
       },
-      "oneOf": [{
-          "required": [
-            "operationRef"
-          ]
+      "oneOf": [
+        {
+          "required": ["operationRef"]
         },
         {
-          "required": [
-            "operationId"
-          ]
+          "required": ["operationId"]
         }
       ],
       "$ref": "#/$defs/specification-extensions",
@@ -930,9 +851,7 @@
     "link-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -965,15 +884,12 @@
           "maxProperties": 1
         }
       },
-      "oneOf": [{
-          "required": [
-            "schema"
-          ]
+      "oneOf": [
+        {
+          "required": ["schema"]
         },
         {
-          "required": [
-            "content"
-          ]
+          "required": ["content"]
         }
       ],
       "dependentSchemas": {
@@ -997,9 +913,7 @@
     "header-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -1022,9 +936,7 @@
           "$ref": "#/$defs/external-documentation"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -1047,32 +959,22 @@
     "schema": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#schema-object",
       "$dynamicAnchor": "meta",
-      "type": [
-        "object",
-        "boolean"
-      ]
+      "type": ["object", "boolean"]
     },
     "security-scheme": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#security-scheme-object",
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "apiKey",
-            "http",
-            "mutualTLS",
-            "oauth2",
-            "openIdConnect"
-          ]
+          "enum": ["apiKey", "http", "mutualTLS", "oauth2", "openIdConnect"]
         },
         "description": {
           "type": "string"
         }
       },
-      "required": [
-        "type"
-      ],
-      "allOf": [{
+      "required": ["type"],
+      "allOf": [
+        {
           "$ref": "#/$defs/specification-extensions"
         },
         {
@@ -1100,9 +1002,7 @@
                 "const": "apiKey"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "properties": {
@@ -1110,17 +1010,10 @@
                 "type": "string"
               },
               "in": {
-                "enum": [
-                  "query",
-                  "header",
-                  "cookie"
-                ]
+                "enum": ["query", "header", "cookie"]
               }
             },
-            "required": [
-              "name",
-              "in"
-            ]
+            "required": ["name", "in"]
           }
         },
         "type-http": {
@@ -1130,9 +1023,7 @@
                 "const": "http"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "properties": {
@@ -1140,9 +1031,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "scheme"
-            ]
+            "required": ["scheme"]
           }
         },
         "type-http-bearer": {
@@ -1156,10 +1045,7 @@
                 "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
               }
             },
-            "required": [
-              "type",
-              "scheme"
-            ]
+            "required": ["type", "scheme"]
           },
           "then": {
             "properties": {
@@ -1176,9 +1062,7 @@
                 "const": "oauth2"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "properties": {
@@ -1186,9 +1070,7 @@
                 "$ref": "#/$defs/oauth-flows"
               }
             },
-            "required": [
-              "flows"
-            ]
+            "required": ["flows"]
           }
         },
         "type-oidc": {
@@ -1198,9 +1080,7 @@
                 "const": "openIdConnect"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "properties": {
@@ -1209,9 +1089,7 @@
                 "format": "uri"
               }
             },
-            "required": [
-              "openIdConnectUrl"
-            ]
+            "required": ["openIdConnectUrl"]
           }
         }
       }
@@ -1219,9 +1097,7 @@
     "security-scheme-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -1264,10 +1140,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "authorizationUrl",
-            "scopes"
-          ],
+          "required": ["authorizationUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions",
           "unevaluatedProperties": false
         },
@@ -1286,10 +1159,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions",
           "unevaluatedProperties": false
         },
@@ -1308,10 +1178,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions",
           "unevaluatedProperties": false
         },
@@ -1334,11 +1201,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "authorizationUrl",
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["authorizationUrl", "tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions",
           "unevaluatedProperties": false
         }
@@ -1384,9 +1247,7 @@
             "const": "form"
           }
         },
-        "required": [
-          "style"
-        ]
+        "required": ["style"]
       },
       "then": {
         "properties": {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -163,8 +163,9 @@ export namespace OpenAPIV3 {
     externalDocs?: ExternalDocumentationObject;
   }
 
-  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths'> {
-    paths?: DocumentV3['paths']
+  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths' | 'info'> {
+    paths?: DocumentV3['paths'];
+    info: InfoObjectV3_1;
     webhooks: {
       [name: string]: PathItemObject | ReferenceObject
     } 
@@ -177,6 +178,10 @@ export namespace OpenAPIV3 {
     contact?: ContactObject;
     license?: LicenseObject;
     version: string;
+  }
+
+  interface InfoObjectV3_1 extends InfoObject {
+    summary: string;
   }
 
   export interface ContactObject {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -21,7 +21,7 @@ export interface ValidationSchema extends ParametersSchema {
 }
 
 export interface OpenAPIFrameworkInit {
-  apiDoc: OpenAPIV3.Document;
+  apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
   basePaths: string[];
 }
 export type SecurityHandlers = {
@@ -109,7 +109,7 @@ export type SerDesMap = {
 };
 
 export interface OpenApiValidatorOpts {
-  apiSpec: OpenAPIV3.Document | string;
+  apiSpec: OpenAPIV3.DocumentV3 | string;
   validateApiSpec?: boolean;
   validateResponses?: boolean | ValidateResponseOpts;
   validateRequests?: boolean | ValidateRequestOpts;
@@ -152,7 +152,7 @@ export interface NormalizedOpenApiValidatorOpts extends OpenApiValidatorOpts {
 }
 
 export namespace OpenAPIV3 {
-  export interface Document {
+  export interface DocumentV3 {
     openapi: string;
     info: InfoObject;
     servers?: ServerObject[];
@@ -161,6 +161,13 @@ export namespace OpenAPIV3 {
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
+  }
+
+  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths'> {
+    paths?: DocumentV3['paths']
+    webhooks: {
+      [name: string]: PathItemObject | ReferenceObject
+    } 
   }
 
   export interface InfoObject {
@@ -474,7 +481,7 @@ export interface OpenAPIFrameworkPathObject {
 }
 
 interface OpenAPIFrameworkArgs {
-  apiDoc: OpenAPIV3.Document | string;
+  apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1 | string;
   validateApiSpec?: boolean;
   $refParser?: {
     mode: 'bundle' | 'dereference';
@@ -484,7 +491,7 @@ interface OpenAPIFrameworkArgs {
 export interface OpenAPIFrameworkAPIContext {
   // basePaths: BasePath[];
   basePaths: string[];
-  getApiDoc(): OpenAPIV3.Document;
+  getApiDoc(): OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
 }
 
 export interface OpenAPIFrameworkVisitor {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -163,9 +163,14 @@ export namespace OpenAPIV3 {
     externalDocs?: ExternalDocumentationObject;
   }
 
-  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths' | 'info'> {
+  interface ComponentsV3_1 extends ComponentsObject {
+    pathItems?: { [path: string]: PathItemObject | ReferenceObject }
+  }
+
+  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths' | 'info' | 'components'> {
     paths?: DocumentV3['paths'];
     info: InfoObjectV3_1;
+    components: ComponentsV3_1;
     webhooks: {
       [name: string]: PathItemObject | ReferenceObject
     } 

--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -15,7 +15,7 @@ import { httpMethods } from './parsers/schema.preprocessor';
 
 export function applyOpenApiMetadata(
   openApiContext: OpenApiContext,
-  responseApiDoc: OpenAPIV3.Document,
+  responseApiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
 ): OpenApiRequestHandler {
   return (req: OpenApiRequest, res: Response, next: NextFunction): void => {
     // note base path is empty when path is fully qualified i.e. req.path.startsWith('')

--- a/src/middlewares/openapi.multipart.ts
+++ b/src/middlewares/openapi.multipart.ts
@@ -15,7 +15,7 @@ import { MulterError } from 'multer';
 const multer = require('multer');
 
 export function multipart(
-  apiDoc: OpenAPIV3.Document,
+  apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
   options: MultipartOpts,
 ): OpenApiRequestHandler {
   const mult = multer(options.multerOpts);

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -21,6 +21,7 @@ import {
 import { BodySchemaParser } from './parsers/body.parse';
 import { ParametersSchemaParser } from './parsers/schema.parse';
 import { RequestParameterMutator } from './parsers/req.parameter.mutator';
+import { debug } from 'console';
 
 type OperationObject = OpenAPIV3.OperationObject;
 type SchemaObject = OpenAPIV3.SchemaObject;
@@ -31,13 +32,13 @@ type ApiKeySecurityScheme = OpenAPIV3.ApiKeySecurityScheme;
 
 export class RequestValidator {
   private middlewareCache: { [key: string]: RequestHandler } = {};
-  private apiDoc: OpenAPIV3.Document;
+  private apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
   private ajv: Ajv;
   private ajvBody: Ajv;
   private requestOpts: ValidateRequestOpts = {};
 
   constructor(
-    apiDoc: OpenAPIV3.Document,
+    apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
     options: RequestValidatorOptions = {},
   ) {
     this.middlewareCache = {};
@@ -267,7 +268,7 @@ export class RequestValidator {
 }
 
 class Validator {
-  private readonly apiDoc: OpenAPIV3.Document;
+  private readonly apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
   readonly schemaGeneral: object;
   readonly schemaBody: object;
   readonly validatorGeneral: ValidateFunction;
@@ -275,7 +276,7 @@ class Validator {
   readonly allSchemaProperties: ValidationSchema;
 
   constructor(
-    apiDoc: OpenAPIV3.Document,
+    apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
     parametersSchema: ParametersSchema,
     bodySchema: BodySchema,
     ajv: {
@@ -329,7 +330,7 @@ class Validator {
 
 class Security {
   public static queryParam(
-    apiDocs: OpenAPIV3.Document,
+    apiDocs: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
     schema: OperationObject,
   ): string[] {
     const hasPathSecurity = schema.security?.length > 0 ?? false;

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -21,7 +21,6 @@ import {
 import { BodySchemaParser } from './parsers/body.parse';
 import { ParametersSchemaParser } from './parsers/schema.parse';
 import { RequestParameterMutator } from './parsers/req.parameter.mutator';
-import { debug } from 'console';
 
 type OperationObject = OpenAPIV3.OperationObject;
 type SchemaObject = OpenAPIV3.SchemaObject;

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -27,14 +27,14 @@ interface ValidateResult {
 }
 export class ResponseValidator {
   private ajvBody: Ajv;
-  private spec: OpenAPIV3.Document;
+  private spec: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
   private validatorsCache: {
     [key: string]: { [key: string]: ValidateFunction };
   } = {};
   private eovOptions: ValidateResponseOpts;
 
   constructor(
-    openApiSpec: OpenAPIV3.Document,
+    openApiSpec: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
     options: Options = {},
     eovOptions: ValidateResponseOpts = {},
   ) {

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -23,7 +23,7 @@ interface SecurityHandlerResult {
   error?: string;
 }
 export function security(
-  apiDoc: OpenAPIV3.Document,
+  apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
   securityHandlers: SecurityHandlers,
 ): OpenApiRequestHandler {
   return async (req, res, next) => {

--- a/src/middlewares/parsers/req.parameter.mutator.ts
+++ b/src/middlewares/parsers/req.parameter.mutator.ts
@@ -39,14 +39,14 @@ type Schema = ReferenceObject | SchemaObject;
  * the request is mutated to accomodate various styles and types e.g. form, explode, deepObject, etc
  */
 export class RequestParameterMutator {
-  private _apiDocs: OpenAPIV3.Document;
+  private _apiDocs: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
   private path: string;
   private ajv: Ajv;
   private parsedSchema: ValidationSchema;
 
   constructor(
     ajv: Ajv,
-    apiDocs: OpenAPIV3.Document,
+    apiDocs: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
     path: string,
     parsedSchema: ValidationSchema,
   ) {

--- a/src/middlewares/parsers/schema.parse.ts
+++ b/src/middlewares/parsers/schema.parse.ts
@@ -17,9 +17,9 @@ type Parameter = OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject;
  */
 export class ParametersSchemaParser {
   private _ajv: Ajv;
-  private _apiDocs: OpenAPIV3.Document;
+  private _apiDocs: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
 
-  constructor(ajv: Ajv, apiDocs: OpenAPIV3.Document) {
+  constructor(ajv: Ajv, apiDocs: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1) {
     this._ajv = ajv;
     this._apiDocs = apiDocs;
   }

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -127,8 +127,8 @@ export class SchemaPreprocessor {
     // Traverse the schemas
     if (r) {
       this.traverseSchemas(schemaNodes, (parent, schema, opts) =>
-      this.schemaVisitor(parent, schema, opts),
-    );
+        this.schemaVisitor(parent, schema, opts),
+      );
     }
 
     return {

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -504,7 +504,7 @@ export class SchemaPreprocessor {
     const op = node.schema;
     const responses = op.responses;
 
-    if (!responses) return;
+    if (!responses) return [];
 
     const schemas: Root<SchemaObject>[] = [];
     for (const [statusCode, response] of Object.entries(responses)) {

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -157,6 +157,11 @@ export class SchemaPreprocessor {
 
     for (const [p, pi] of Object.entries(this.apiDoc.paths)) {
       const pathItem = this.resolveSchema<OpenAPIV3.PathItemObject>(pi);
+
+      // Since OpenAPI 3.1, paths can be a #ref to reusable path items
+      // The following line mutates the paths item to dereference the reference, so that we can process as a POJO, as we would if it wasn't a reference
+      this.apiDoc.paths[p] = pathItem;
+      
       for (const method of Object.keys(pathItem)) {
         if (httpMethods.has(method)) {
           const operation = <OpenAPIV3.OperationObject>pathItem[method];

--- a/src/middlewares/parsers/util.ts
+++ b/src/middlewares/parsers/util.ts
@@ -4,7 +4,7 @@ import ajv = require('ajv');
 import { OpenAPIFramework } from '../../framework';
 
 export function dereferenceParameter(
-  apiDocs: OpenAPIV3.Document,
+  apiDocs: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
   parameter: OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject,
 ): OpenAPIV3.ParameterObject {
   // TODO this should recurse or use ajv.getSchema - if implemented as such, may want to cache the result

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -261,26 +261,26 @@ export class OpenApiValidator {
 
   private metadataMiddleware(
     context: OpenApiContext,
-    responseApiDoc: OpenAPIV3.Document,
+    responseApiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
   ) {
     return middlewares.applyOpenApiMetadata(context, responseApiDoc);
   }
 
-  private multipartMiddleware(apiDoc: OpenAPIV3.Document) {
+  private multipartMiddleware(apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1) {
     return middlewares.multipart(apiDoc, {
       multerOpts: this.options.fileUploader,
       ajvOpts: this.ajvOpts.multipart,
     });
   }
 
-  private securityMiddleware(apiDoc: OpenAPIV3.Document) {
+  private securityMiddleware(apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1) {
     const securityHandlers = (<ValidateSecurityOpts>(
       this.options.validateSecurity
     ))?.handlers;
     return middlewares.security(apiDoc, securityHandlers);
   }
 
-  private requestValidationMiddleware(apiDoc: OpenAPIV3.Document) {
+  private requestValidationMiddleware(apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1) {
     const requestValidator = new middlewares.RequestValidator(
       apiDoc,
       this.ajvOpts.request,
@@ -288,7 +288,7 @@ export class OpenApiValidator {
     return (req, res, next) => requestValidator.validate(req, res, next);
   }
 
-  private responseValidationMiddleware(apiDoc: OpenAPIV3.Document) {
+  private responseValidationMiddleware(apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1) {
     return new middlewares.ResponseValidator(
       apiDoc,
       this.ajvOpts.response,

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -7,7 +7,7 @@ const cache = {};
 export function defaultResolver(
   handlersPath: string,
   route: RouteMetadata,
-  apiDoc: OpenAPIV3.Document,
+  apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
 ): RequestHandler {
   const tmpModules = {};
   const { basePath, expressRoute, openApiRoute, method } = route;
@@ -51,7 +51,7 @@ export function defaultResolver(
 export function modulePathResolver(
   handlersPath: string,
   route: RouteMetadata,
-  apiDoc: OpenAPIV3.Document,
+  apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
 ): RequestHandler {
   const pathKey = route.openApiRoute.substring(route.basePath.length);
   const schema = apiDoc.paths[pathKey][route.method.toLowerCase()];

--- a/test/440.spec.ts
+++ b/test/440.spec.ts
@@ -9,7 +9,7 @@ describe(packageJson.name, () => {
 
   before(async () => {
     // Set up the express app
-    const apiSpec: OpenAPIV3.Document = {
+    const apiSpec: OpenAPIV3.DocumentV3 = {
       openapi: '3.0.0',
       info: { title: 'Api test', version: '1.0.0' },
       servers: [{ url: '/api' }],

--- a/test/478.spec.ts
+++ b/test/478.spec.ts
@@ -53,7 +53,7 @@ describe('issue #478', () => {
       .expect(200));
 });
 
-function apiSpec(): OpenAPIV3.Document {
+function apiSpec(): OpenAPIV3.DocumentV3 {
   return {
     openapi: '3.0.3',
     info: {

--- a/test/535.spec.ts
+++ b/test/535.spec.ts
@@ -19,7 +19,7 @@ describe('#535 - calling `middleware()` multiple times', () => {
 });
 
 async function createApp(
-  apiSpec: OpenAPIV3.Document,
+  apiSpec: OpenAPIV3.DocumentV3,
 ): Promise<express.Express & { server?: Server }> {
   const app = express();
 
@@ -39,7 +39,7 @@ async function createApp(
   return app;
 }
 
-function createApiSpec(): OpenAPIV3.Document {
+function createApiSpec(): OpenAPIV3.DocumentV3 {
   return {
     openapi: '3.0.3',
     info: {

--- a/test/577.spec.ts
+++ b/test/577.spec.ts
@@ -21,7 +21,7 @@ describe('#577 - Exclude response validation that is not in api spec', () => {
 });
 
 async function createApp(
-  apiSpec: OpenAPIV3.Document,
+  apiSpec: OpenAPIV3.DocumentV3,
 ): Promise<express.Express & { server?: Server }> {
   const app = express();
 
@@ -51,7 +51,7 @@ async function createApp(
   return app;
 }
 
-function createApiSpec(): OpenAPIV3.Document {
+function createApiSpec(): OpenAPIV3.DocumentV3 {
   return {
     openapi: '3.0.3',
     info: {

--- a/test/699.spec.ts
+++ b/test/699.spec.ts
@@ -182,7 +182,6 @@ describe('699 serialize response components only', () => {
       3005,
       (app) => {
         app.get([`${app.basePath}/users/:id?`], (req, res) => {
-          debugger;
           if (typeof req.params.id !== 'string') {
             throw new Error("Should be not be deserialized to ObjectId object");
           }

--- a/test/821.spec.ts
+++ b/test/821.spec.ts
@@ -30,7 +30,7 @@ describe('issue #821 - serialization inside addiotionalProperties', () => {
 });
 
 async function createApp(
-  apiSpec: OpenAPIV3.Document | string,
+  apiSpec: OpenAPIV3.DocumentV3 | string,
 ): Promise<express.Express & { server?: Server }> {
   const app = express();
 

--- a/test/allow.header.spec.ts
+++ b/test/allow.header.spec.ts
@@ -50,7 +50,7 @@ async function createApp(): Promise<express.Express & { server?: Server }> {
   return app;
 }
 
-function createApiSpec(): OpenAPIV3.Document {
+function createApiSpec(): OpenAPIV3.DocumentV3 {
   return {
     openapi: '3.0.3',
     info: {

--- a/test/invalid.apispec.spec.ts
+++ b/test/invalid.apispec.spec.ts
@@ -41,7 +41,7 @@ async function createApp(
   return app;
 }
 
-function createApiSpec(): OpenAPIV3.Document {
+function createApiSpec(): OpenAPIV3.DocumentV3 {
   return <any>{
     openapi: '3.0.3',
     info: {

--- a/test/no.components.spec.ts
+++ b/test/no.components.spec.ts
@@ -33,7 +33,7 @@ describe('no components', () => {
       }));
 });
 
-function apiDoc(): OpenAPIV3.Document {
+function apiDoc(): OpenAPIV3.DocumentV3 {
   return {
     openapi: '3.0.1',
     info: {

--- a/test/openapi_3.1/README.md
+++ b/test/openapi_3.1/README.md
@@ -1,0 +1,3 @@
+# Open API 3.1 tests
+
+This folder, and its subfolders, contain tests for OpenAPI specification 3.1

--- a/test/openapi_3.1/components.spec.ts
+++ b/test/openapi_3.1/components.spec.ts
@@ -1,0 +1,30 @@
+import * as request from 'supertest';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('components support - OpenAPI 3.1', () => {
+  let app;
+
+  before(async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'components.yaml');
+    app = await createApp(
+      { apiSpec, validateRequests: true },
+      3005,
+      undefined,
+      false,
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should support an API that only has components defined, but provides no routes', () => {
+    // The component is not made available by the provider API, so the request will return 404
+    // This test ensures that the request flow happens normally without any interruptions due to being a component
+    return request(app)
+      .get(`${app.basePath}/components`)
+      .expect(404);
+  });
+
+})

--- a/test/openapi_3.1/components_path_items.spec.ts
+++ b/test/openapi_3.1/components_path_items.spec.ts
@@ -1,0 +1,34 @@
+import * as request from 'supertest';
+import * as express from 'express';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('component path item support - OpenAPI 3.1', () => {
+  let app;
+
+  before(async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'components_path_items.yaml');
+    app = await createApp(
+      { apiSpec, validateRequests: true, validateResponses: true },
+      3005,
+      (app) => app.use(
+        express
+          .Router()
+          .get(`/v1/entity`, (req, res) =>
+            res.status(200).json({}),
+          ),
+      )
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should support path item on components', async () => {
+    return request(app)
+      .get(`${app.basePath}/entity`)
+      .expect(200);
+  });
+
+})

--- a/test/openapi_3.1/info_summary.spec.ts
+++ b/test/openapi_3.1/info_summary.spec.ts
@@ -1,0 +1,30 @@
+import * as request from 'supertest';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('summary support - OpenAPI 3.1', () => {
+  let app;
+
+  before(async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'info_summary.yaml');
+    app = await createApp(
+      { apiSpec, validateRequests: true },
+      3005,
+      undefined,
+      false,
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should support an API that has an info with a summary defined', () => {
+    // The endpoint is not made available by the provider API, so the request will return 404
+    // This test ensures that the request flow happens normally without any interruptions
+    return request(app)
+      .get(`${app.basePath}/webhook`)
+      .expect(404);
+  });
+
+})

--- a/test/openapi_3.1/license_identifier.spec.ts
+++ b/test/openapi_3.1/license_identifier.spec.ts
@@ -1,0 +1,30 @@
+import * as request from 'supertest';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('identifier support - OpenAPI 3.1', () => {
+  let app;
+
+  before(async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'license_identifier.yaml');
+    app = await createApp(
+      { apiSpec, validateRequests: true },
+      3005,
+      undefined,
+      false,
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should support an API that has an info with a summary defined', () => {
+    // The endpoint is not made available by the provider API, so the request will return 404
+    // This test ensures that the request flow happens normally without any interruptions
+    return request(app)
+      .get(`${app.basePath}/webhook`)
+      .expect(404);
+  });
+
+})

--- a/test/openapi_3.1/non_defined_semantics_request_body.spec.ts
+++ b/test/openapi_3.1/non_defined_semantics_request_body.spec.ts
@@ -1,0 +1,48 @@
+import * as request from 'supertest';
+import * as express from 'express';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('Request body in operations without well defined semantics - OpenAPI 3.1', () => {
+  let app;
+
+  before(async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'non_defined_semantics_request_body.yaml');
+    app = await createApp(
+      { apiSpec, validateRequests: true, validateResponses: true },
+      3005,
+      (app) => app.use(
+        express
+          .Router()
+          .get(`/v1/entity`, (req, res) =>
+            res.status(200).json({
+              property: null
+            }),
+          ),
+      )
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  // In OpenAPI 3.0, methods that RFC7231 does not have explicitly defined semantics for request body (GET, HEAD, DELETE) do not allow request body
+  // In OpenAPI 3.1, request body is allowed for these methods. This test ensures that GET it is correctly handled
+  it('should validate a request body on GET', async () => {
+    return request(app)
+      .get(`${app.basePath}/entity`)
+      .set('Content-Type', 'application/json')
+      .send({request: 123})
+      .expect(400);
+  });
+
+  // Ensures that DELETE it is correctly handled
+  it('should validate a request body on DELETE', async () => {
+    return request(app)
+      .delete(`${app.basePath}/entity`)
+      .set('Content-Type', 'application/json')
+      .send({request: 123})
+      .expect(400);
+  });
+})

--- a/test/openapi_3.1/path_no_response.spec.ts
+++ b/test/openapi_3.1/path_no_response.spec.ts
@@ -1,0 +1,36 @@
+import * as request from 'supertest';
+import * as express from 'express';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('operation object without response - OpenAPI 3.1', () => {
+  let app;
+
+  before(async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'path_no_response.yaml');
+    app = await createApp(
+      { apiSpec, validateRequests: true, validateResponses: true },
+      3005,
+      (app) => app.use(
+        express
+          .Router()
+          .get(`/v1`, (req, res) =>
+            res.status(200).end(),
+          ),
+      )
+    );
+    app
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  // In OpenAPI 3.1 it's possible to have a path without a response defined
+  it('should support endpoint with defined operation object without response', () => {
+    return request(app)
+      .get(`${app.basePath}`)
+      .expect(200);
+  });
+
+})

--- a/test/openapi_3.1/resources/components.yaml
+++ b/test/openapi_3.1/resources/components.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+components: {}

--- a/test/openapi_3.1/resources/components.yaml
+++ b/test/openapi_3.1/resources/components.yaml
@@ -1,3 +1,4 @@
+# From https://github.com/OAI/OpenAPI-Specification/blob/6f386968654fd483720aba0177e618e87a5d612d/tests/v3.1/pass/minimal_comp.yaml
 openapi: 3.1.0
 info:
   title: API

--- a/test/openapi_3.1/resources/components_path_items.yaml
+++ b/test/openapi_3.1/resources/components_path_items.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.0
+info:
+  title: Example specification
+  version: "1.0"
+servers:
+  - url: /v1
+components:
+  pathItems: 
+    entity:
+      get: 
+        description: 'test'
+        responses: 
+          200:
+            description: GETS my entity
+            content:
+              application/json:
+                schema:
+                    type: object
+paths:
+  /entity:
+    $ref: '#/components/pathItems/entity'

--- a/test/openapi_3.1/resources/info_summary.yaml
+++ b/test/openapi_3.1/resources/info_summary.yaml
@@ -1,0 +1,7 @@
+# From https://github.com/OAI/OpenAPI-Specification/blob/6f386968654fd483720aba0177e618e87a5d612d/tests/v3.1/pass/info_summary.yaml
+openapi: 3.1.0
+info:
+  title: API
+  summary: My lovely API
+  version: 1.0.0
+components: {}

--- a/test/openapi_3.1/resources/license_identifier.yaml
+++ b/test/openapi_3.1/resources/license_identifier.yaml
@@ -1,0 +1,10 @@
+# From https://github.com/OAI/OpenAPI-Specification/blob/6f386968654fd483720aba0177e618e87a5d612d/tests/v3.1/pass/license_identifier.yaml
+openapi: 3.1.0
+info:
+  title: API
+  summary: My lovely API
+  version: 1.0.0
+  license:
+    name: Apache
+    identifier: Apache-2.0
+components: {}

--- a/test/openapi_3.1/resources/non_defined_semantics_request_body.yaml
+++ b/test/openapi_3.1/resources/non_defined_semantics_request_body.yaml
@@ -1,0 +1,55 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+servers:
+  - url: /v1
+components:
+  schemas:
+    EntityRequest:
+      type: object
+      properties:
+        request:
+          type: string
+paths:
+  /entity:
+    get:
+      description: GETS my entity
+      requestBody:
+        description: Request body for entity
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json: 
+              schema:
+                title: Entity
+                type: object
+                properties:
+                  property:
+                    type: ['string', 'null']
+    delete:
+      description: DELETE my entity
+      requestBody:
+        description: Request body for entity
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json: 
+              schema:
+                title: Entity
+                type: object
+                properties:
+                  property:
+                    type: ['string', 'null']

--- a/test/openapi_3.1/resources/path_no_response.yaml
+++ b/test/openapi_3.1/resources/path_no_response.yaml
@@ -1,0 +1,11 @@
+# Adapted from https://github.com/OAI/OpenAPI-Specification/blob/77c7b9a522ab6fb83a49e8088fa600e93da4f44e/tests/v3.1/pass/path_no_response.yaml
+
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+servers:
+  - url: /v1
+paths:
+  /:
+    get: {}

--- a/test/openapi_3.1/resources/server_variable_no_default.yaml
+++ b/test/openapi_3.1/resources/server_variable_no_default.yaml
@@ -1,0 +1,13 @@
+# Adapted from https://github.com/OAI/OpenAPI-Specification/blob/77c7b9a522ab6fb83a49e8088fa600e93da4f44e/tests/v3.1/fail/server_enum_empty.yaml
+
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+servers:
+  - url: https://example.com/test
+    variables:
+      var:
+        enum: ['a', 'b']
+components:
+  {}

--- a/test/openapi_3.1/resources/type_null.yaml
+++ b/test/openapi_3.1/resources/type_null.yaml
@@ -1,0 +1,23 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+servers:
+  - url: /v1
+paths:
+  /entity:
+    get:
+        summary: test
+        description: GETS my entity
+        responses:
+          '200':
+            description: OK
+            content:
+              application/json: 
+                schema:
+                  title: Entity
+                  type: object
+                  properties:
+                    property:
+                      type: ['string', 'null']
+              

--- a/test/openapi_3.1/resources/webhook.yaml
+++ b/test/openapi_3.1/resources/webhook.yaml
@@ -1,0 +1,35 @@
+# From https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.1/webhook-example.yaml
+openapi: 3.1.0
+info:
+  title: Webhook Example
+  version: 1.0.0
+# Since OAS 3.1.0 the paths element isn't necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components
+webhooks:
+  # Each webhook needs a name
+  newPet:
+    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/test/openapi_3.1/server_variable.spec.ts
+++ b/test/openapi_3.1/server_variable.spec.ts
@@ -1,0 +1,21 @@
+import * as request from 'supertest';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('server variable - OpenAPI 3.1', () => {
+  it('returns 500 when server variable has no default property', async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'server_variable_no_default.yaml');
+    const app = await createApp(
+      { apiSpec, validateRequests: true, validateResponses: true },
+      3005,
+      undefined,
+      false,
+    ) as any;
+
+    await request(app)
+      .get(`${app.basePath}`)
+      .expect(500);
+
+    app.server.close();
+  });
+})

--- a/test/openapi_3.1/type_null.spec.ts
+++ b/test/openapi_3.1/type_null.spec.ts
@@ -1,0 +1,37 @@
+import * as request from 'supertest';
+import * as express from 'express';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('type null support - OpenAPI 3.1', () => {
+  let app;
+
+  before(async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'type_null.yaml');
+    app = await createApp(
+      { apiSpec, validateRequests: true, validateResponses: true },
+      3005,
+      (app) => app.use(
+        express
+          .Router()
+          .get(`/v1/entity`, (req, res) =>
+            res.status(200).json({
+              property: null
+            }),
+          ),
+      )
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  // In OpenAPI 3.1, nullable = true was replaced by types = [..., null]. This test ensure that it works with Express OpenAPI Validator
+  it('should support an API with types set to null', async () => {
+    return request(app)
+      .get(`${app.basePath}/entity`)
+      .expect(200);
+  });
+
+})

--- a/test/openapi_3.1/webhook.spec.ts
+++ b/test/openapi_3.1/webhook.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import * as request from 'supertest';
 import { createApp } from "../common/app";
 import { join } from "path";

--- a/test/openapi_3.1/webhook.spec.ts
+++ b/test/openapi_3.1/webhook.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import * as request from 'supertest';
+import { createApp } from "../common/app";
+import { join } from "path";
+
+describe('webhook support - OpenAPI 3.1', () => {
+  let app;
+
+  before(async () => {
+    const apiSpec = join('test', 'openapi_3.1', 'resources', 'webhook.yaml');
+    app = await createApp(
+      { apiSpec, validateRequests: true },
+      3005,
+      undefined,
+      false,
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should support an API that only has webhooks defined, but provides no routes', () => {
+    // The webhook is not made available by the provider API, so the request will return 404
+    // This test ensures that the request flow happens normally without any interruptions due to being a webhook
+    return request(app)
+      .get(`${app.basePath}/webhook`)
+      .expect(404);
+  });
+
+})

--- a/test/petstore.spec.ts
+++ b/test/petstore.spec.ts
@@ -36,7 +36,7 @@ describe('petstore', () => {
     request(app).get(`${app.basePath}/pets`).expect(200));
 });
 
-function petstoreSpec(): OpenAPIV3.Document {
+function petstoreSpec(): OpenAPIV3.DocumentV3 {
   return {
     openapi: '3.0.0',
     info: {

--- a/test/user-request-url.router.spec.ts
+++ b/test/user-request-url.router.spec.ts
@@ -112,7 +112,7 @@ function defaultResponse(): OpenAPIV3.ResponseObject {
    type of id in path and id in the response here defined as simple string
    with minLength
  */
-const gatewaySpec: OpenAPIV3.Document = {
+const gatewaySpec: OpenAPIV3.DocumentV3 = {
   openapi: '3.0.0',
   info: { version: '1.0.0', title: 'test bug OpenApiValidator' },
   servers: [{ url: 'http://localhost:3000/api' }],
@@ -168,7 +168,7 @@ const gatewaySpec: OpenAPIV3.Document = {
  represents spec of the child router. We route request from main app (gateway) to this router.
  This router has its own schema, routes and validation formats. In particular, we force id in the path and id in the response to be uuid.
  */
-const childRouterSpec: OpenAPIV3.Document = {
+const childRouterSpec: OpenAPIV3.DocumentV3 = {
   openapi: '3.0.0',
   info: { version: '1.0.0', title: 'test bug OpenApiValidator' },
   servers: [{ url: 'http://localhost:3000/' }],


### PR DESCRIPTION
- This PR adds support for OpenAPI version 3.1. This has been tried before, as described in https://github.com/cdimascio/express-openapi-validator/issues/573, but these attempts failed. Mainly due to a bug in AJV that makes it incompatible with OpenAPI version 3.1 - https://github.com/ajv-validator/ajv/issues/1745

This PR circumvents AJV issue by replacing all $dynamicAnchor keywords in OpenAPI schema with a direct reference, using $ref. This has been suggested by @Jackman3005 in https://github.com/cdimascio/express-openapi-validator/issues/573#issuecomment-1869810476, which originally came from @seriousme, which already made this workaround in his own OpenAPI schema validation library, https://github.com/seriousme/openapi-schema-validator. From what I understand this shouldn't be an issue. Using $dynamicAnchor would allow this lib to replace OpenAPI specification definitions, which it does not do.

# Changes
- `openapi.schema.validator.ts` now creates a different AJV instance that supports JSON schema 2020-12 when it detects version 3.1. This AJV instance accepts the format `media-range` but does not validate its content. This validation can be made in another PR
- Adds OpenAPI specification 3.1 with $dynamicAnchor references changed to $ref
- Change test scripts to use Mocha's `--extension` flag. With the previous setup, the new tests weren't being picked up by the runner

# OpenAPI 3.1 support

- [x] Support webhook property without any defined paths
- [x] Support an API with only components
- [x] Fully complete Open API 3.1 schema in type.ts
- [x] Support "summary" in Info Object
- [x] Support "identifier" field for SPDX licenses in License Object
- [x] Ensure "nullable" property does not work anymore. Null type works instead
- [x] Ensure Request Body validation works in GET HTTP methods
- [x] Ensure "default" must exist in server variable "enum" values
- [x] Ensure it is possible to create an Operation Object without `responses`
- [x] Support "pathItems" in Components Object

There are some more changes introduced by Open API 3.1, but they're schema changes that are validated by AJV, so tests, although important, aren't as critical as the ones above. They are:

- Ensure mutual TLS works correctly
- Ensure extension prefixed with "x-oas-" is not allowed
- Ensure "exclusiveMaximum" and "exclusiveMinimum" do not accept boolean values
- Ensure server variable "enum" can not be empty
- Ensure "jsonSchemaDialect" is supported
- Ensure "style", "explode" and "allowReserved" for multipart/form-data are allowed as media types


Closes #573 #755