### PR TITLE
docs: fix doc typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - 🎈 file upload
 
 **Docs:**
-- 📖 [documenation](https://github.com/cdimascio/express-openapi-validator/wiki/Documentation)
+- 📖 [documentation](https://github.com/cdimascio/express-openapi-validator/wiki/Documentation)
 
 [![GitHub stars](https://img.shields.io/github/stars/cdimascio/express-openapi-validator.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/cdimascio/express-openapi-validator/stargazers/) [![Twitter URL](https://img.shields.io/twitter/url/https/github.com/cdimascio/express-openapi-validator.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20express-openapi-validator%20by%20%40CarmineDiMascio%20https%3A%2F%2Fgithub.com%2Fcdimascio%2Fexpress-openapi-validator%20%F0%9F%91%8D)
 


### PR DESCRIPTION
Small PR to fix a typo in the Readme documenation -> documentation