### PR TITLE
Fixes for 881 - multiple specs w/validateRequests fail

### DIFF
--- a/examples/2-standard-multiple-api-specs/api.v2.yaml
+++ b/examples/2-standard-multiple-api-specs/api.v2.yaml
@@ -117,9 +117,9 @@ components:
   schemas:
     Pet:
       required:
-        - id
-        - name
-        - type
+        - pet_id
+        - pet_name
+        - pet_type
       properties:
         pet_id:
           readOnly: true

--- a/src/framework/openapi.context.ts
+++ b/src/framework/openapi.context.ts
@@ -12,6 +12,7 @@ export class OpenApiContext {
   public readonly routes: RouteMetadata[] = [];
   public readonly ignoreUndocumented: boolean;
   public readonly useRequestUrl: boolean;
+  public readonly serial: number;
   private readonly basePaths: string[];
   private readonly ignorePaths: RegExp | Function;
 
@@ -28,6 +29,7 @@ export class OpenApiContext {
     this.ignoreUndocumented = ignoreUndocumented;
     this.buildRouteMaps(spec.routes);
     this.useRequestUrl = useRequestUrl;
+    this.serial = spec.serial;
   }
 
   public isManagedRoute(path: string): boolean {

--- a/src/framework/openapi.spec.loader.ts
+++ b/src/framework/openapi.spec.loader.ts
@@ -9,6 +9,7 @@ export interface Spec {
   apiDoc: OpenAPIV3.Document;
   basePaths: string[];
   routes: RouteMetadata[];
+  serial: number;
 }
 
 export interface RouteMetadata {
@@ -23,6 +24,7 @@ interface DiscoveredRoutes {
   apiDoc: OpenAPIV3.Document;
   basePaths: string[];
   routes: RouteMetadata[];
+  serial: number;
 }
 // Sort routes by most specific to least specific i.e. static routes before dynamic
 // e.g. /users/my_route before /users/{id}
@@ -32,6 +34,9 @@ export const sortRoutes = (r1, r2) => {
   const e2 = r2.expressRoute.replace(/\/:/g, '/~');
   return e1 > e2 ? 1 : -1;
 };
+
+// Uniquely identify the Spec that is emitted
+let serial = 0;
 
 export class OpenApiSpecLoader {
   private readonly framework: OpenAPIFramework;
@@ -91,10 +96,12 @@ export class OpenApiSpecLoader {
 
     routes.sort(sortRoutes);
 
+    serial = serial + 1;
     return {
       apiDoc,
       basePaths,
       routes,
+      serial
     };
   }
 

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -497,6 +497,7 @@ export interface OpenApiRequestMetadata {
   openApiRoute: string;
   pathParams: { [index: string]: string };
   schema: OpenAPIV3.OperationObject;
+  serial: number;
 }
 
 export interface OpenApiRequest extends Request {

--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -48,6 +48,7 @@ export function applyOpenApiMetadata(
         openApiRoute: openApiRoute,
         pathParams: pathParams,
         schema: schema,
+        serial: openApiContext.serial,
       };
       req.params = pathParams;
       if (responseApiDoc) {
@@ -101,6 +102,7 @@ export function applyOpenApiMetadata(
             expressRoute,
             openApiRoute,
             pathParams,
+            serial: -1,
           };
           (<any>r)._responseSchema = _schema;
           return r;

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -32,15 +32,18 @@ export class ResponseValidator {
     [key: string]: { [key: string]: ValidateFunction };
   } = {};
   private eovOptions: ValidateResponseOpts;
+  private serial: number;
 
   constructor(
     openApiSpec: OpenAPIV3.Document,
     options: Options = {},
     eovOptions: ValidateResponseOpts = {},
+    serial: number = -1,
   ) {
     this.spec = openApiSpec;
     this.ajvBody = createResponseAjv(openApiSpec, options);
     this.eovOptions = eovOptions;
+    this.serial = serial;
 
     // This is a pseudo-middleware function. It doesn't get registered with
     // express via `use`
@@ -51,7 +54,7 @@ export class ResponseValidator {
 
   public validate(): RequestHandler {
     return mung.json((body, req, res) => {
-      if (req.openapi) {
+      if (req.openapi && this.serial == req.openapi.serial) {
         const openapi = <OpenApiRequestMetadata>req.openapi;
         // instead of openapi.schema, use openapi._responseSchema to get the response copy
         const responses: OpenAPIV3.ResponsesObject = (<any>openapi)

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -201,8 +201,8 @@ export class OpenApiValidator {
       let resmw;
       middlewares.push(function responseMiddleware(req, res, next) {
         return pContext
-          .then(({ responseApiDoc }) => {
-            resmw = resmw || self.responseValidationMiddleware(responseApiDoc);
+          .then(({ responseApiDoc, context }) => {
+            resmw = resmw || self.responseValidationMiddleware(responseApiDoc, context.serial);
             return resmw(req, res, next);
           })
           .catch(next);
@@ -288,12 +288,13 @@ export class OpenApiValidator {
     return (req, res, next) => requestValidator.validate(req, res, next);
   }
 
-  private responseValidationMiddleware(apiDoc: OpenAPIV3.Document) {
+  private responseValidationMiddleware(apiDoc: OpenAPIV3.Document, serial: number) {
     return new middlewares.ResponseValidator(
       apiDoc,
       this.ajvOpts.response,
       // This has already been converted from boolean if required
       this.options.validateResponses as ValidateResponseOpts,
+      serial
     ).validate();
   }
 

--- a/test/356.campaign.spec.ts
+++ b/test/356.campaign.spec.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+ import * as path from 'path';
 import * as express from 'express';
 import * as request from 'supertest';
 import { createApp } from './common/app';

--- a/test/881.spec.ts
+++ b/test/881.spec.ts
@@ -1,0 +1,119 @@
+import { expect } from 'chai';
+import * as request from 'supertest';
+
+describe('multi-spec', () => {
+  let app = null;
+
+  before(async () => {
+    // Set up the express app
+    app = createServer();
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('create campaign should return 200', async () =>
+    request(app)
+      .get(`/v1/pets`)
+      .expect(400)
+      .then((r) => {
+        expect(r.body.message).include('limit');
+        expect(r.body.message).include(`'type'`);
+      }));
+
+  it('create campaign should return 200', async () =>
+    request(app)
+      .get(`/v2/pets`)
+      .expect(400)
+      .then((r) => {
+        expect(r.body.message).include(`'pet_type'`);
+      }));
+});
+
+function createServer() {
+  const express = require('express');
+  const path = require('path');
+  const bodyParser = require('body-parser');
+  const http = require('http');
+  const OpenApiValidator = require('../src');
+
+  const app = express();
+  app.use(bodyParser.urlencoded({ extended: false }));
+  app.use(bodyParser.text());
+  app.use(bodyParser.json());
+
+  const versions = [1, 2];
+
+  for (const v of versions) {
+    const apiSpec = path.join(__dirname, `api.v${v}.yaml`);
+    app.use(
+      OpenApiValidator.middleware({
+        apiSpec,
+        validateResponses: true,
+      }),
+    );
+
+    routes(app, v);
+  }
+
+  const server = http.createServer(app);
+  server.listen(3000);
+  console.log('Listening on port 3000');
+
+  function routes(app, v) {
+    if (v === 1) routesV1(app);
+    if (v === 2) routesV2(app);
+  }
+
+  function routesV1(app) {
+    const v = '/v1';
+    app.post(`${v}/pets`, (req, res, next) => {
+      res.json({ ...req.body });
+    });
+    app.get(`${v}/pets`, (req, res, next) => {
+      res.json([
+        {
+          id: 1,
+          name: 'happy',
+          type: 'cat',
+        },
+      ]);
+    });
+
+    app.use((err, req, res, next) => {
+      // format error
+      res.status(err.status || 500).json({
+        message: err.message,
+        errors: err.errors,
+      });
+    });
+  }
+
+  function routesV2(app) {
+    const v = '/v2';
+    app.get(`${v}/pets`, (req, res, next) => {
+      res.json([
+        {
+          pet_id: 1,
+          pet_name: 'happy',
+          pet_type: 'kitty',
+        },
+      ]);
+    });
+    app.post(`${v}/pets`, (req, res, next) => {
+      res.json({ ...req.body });
+    });
+
+    app.use((err, req, res, next) => {
+      // format error
+      res.status(err.status || 500).json({
+        message: err.message,
+        errors: err.errors,
+      });
+    });
+  }
+
+  app.server = server;
+  return app;
+}

--- a/test/api.v2.yaml
+++ b/test/api.v2.yaml
@@ -117,9 +117,9 @@ components:
   schemas:
     Pet:
       required:
-        - id
-        - name
-        - type
+        - pet_id
+        - pet_name
+        - pet_type
       properties:
         pet_id:
           readOnly: true


### PR DESCRIPTION
Problem: Multiple api installations cause installation of chained mung'd json implementations each is bound to a specific apiSpec in the surrounding ResponseValidator.  requests are labelled with a specific apiSpec. One (or more) of the chained implementations will then ResponseValidator.validate against a mismatched ResponseValidator.

Solution is:
1. OpenApiSpecLoader.load() decorates its returned Spec with a unique serial number
2. OpenApiContext caches this serial number
3. applyOpenMetadata stores this serial number in the OpenApiRequestMetadata in req.openapi
4. ResponseValidator.constructor caches the serial number when it is created

And, to make it all work,

5. ResponseValidator.validate inside the mung'd json, checks to see if the serial number in req.openapi.serial matches the serial number in the containing ResponseValidator instance.