### PR TITLE
Support async operation handler resolver

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -1,7 +1,8 @@
 import * as ajv from 'ajv';
 import * as multer from 'multer';
-import { FormatsPluginOptions, FormatOptions } from 'ajv-formats';
-import { Request, Response, NextFunction } from 'express';
+import { FormatsPluginOptions } from 'ajv-formats';
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+import { RouteMetadata } from './openapi.spec.loader';
 export { OpenAPIFrameworkArgs };
 
 export type BodySchema =
@@ -63,7 +64,11 @@ export type ValidateSecurityOpts = {
 
 export type OperationHandlerOptions = {
   basePath: string;
-  resolver: Function;
+  resolver: (
+    handlersPath: string,
+    route: RouteMetadata,
+    apiDoc: OpenAPIV3.Document,
+  ) => RequestHandler | Promise<RequestHandler>;
 };
 
 export type Format = {


### PR DESCRIPTION
- Let users define `operationHandlers.resolver` as a synchronous or asynchronous function that returns a request handler
- Make `installOperationHandlers` an asynchronous function that awaits a resolver promise (automatically wraps resolver with promise if needed)
- Update operation handlers middleware to handle an async `installOperationHandlers`.

This is similar to the approach mentioned in #660 but makes it possible to use `await import()` in the resolver so that a new request handler doesn't have to be created as a wrapper. Then, the default resolver requires very little modification. I was able to replace https://github.com/cdimascio/express-openapi-validator/blob/4e8bc84b243b9125a7ec3cbf443d9f6447e94eb6/src/resolvers.ts#L33-L38 with 
```ts
// import {pathToFileURL} from 'node:url';

const modulePath = path.join(handlersPath, baseName);
const moduleUrl = `${pathToFileURL(modulePath).toString()}.js`;
const importedModule = (await import(moduleUrl)) as Record<string, RequestHandler | undefined>;

const handler = importedModule[oId];
```
and otherwise use the default resolver as-is.