### PR TITLE
Support ESM import of handler module in default resolver

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -63,9 +63,9 @@ export type ValidateSecurityOpts = {
 };
 
 export type OperationHandlerOptions = {
-  basePath: string;
+  basePath: string | URL;
   resolver: (
-    handlersPath: string,
+    handlersPath: string | URL,
     route: RouteMetadata,
     apiDoc: OpenAPIV3.Document,
   ) => RequestHandler | Promise<RequestHandler>;
@@ -155,7 +155,7 @@ export interface OpenApiValidatorOpts {
   $refParser?: {
     mode: 'bundle' | 'dereference';
   };
-  operationHandlers?: false | string | OperationHandlerOptions;
+  operationHandlers?: false | string | URL | OperationHandlerOptions;
   validateFormats?: boolean | 'fast' | 'full';
 }
 

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -56,7 +56,7 @@ export class OpenApiValidator {
     if (options.formats == null) options.formats = {};
     if (options.useRequestUrl == null) options.useRequestUrl = false;
 
-    if (typeof options.operationHandlers === 'string') {
+    if (typeof options.operationHandlers === 'string' || options.operationHandlers instanceof URL) {
       /**
        * Internally, we want to convert this to a value typed OperationHandlerOptions.
        * In this way, we can treat the value as such when we go to install (rather than

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -2,40 +2,47 @@ import * as path from 'path';
 import { RequestHandler } from 'express';
 import { RouteMetadata } from './framework/openapi.spec.loader';
 import { OpenAPIV3 } from './framework/types';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+// Prevent TypeScript from replacing dynamic import with require()
+const dynamicImport = new Function('specifier', 'return import(specifier)');
 
 const cache = {};
-export function defaultResolver(
-  handlersPath: string,
+export async function defaultResolver(
+  handlersPath: string | URL,
   route: RouteMetadata,
   apiDoc: OpenAPIV3.Document,
-): RequestHandler {
-  const tmpModules = {};
+): Promise<RequestHandler> {
   const { basePath, expressRoute, openApiRoute, method } = route;
   const pathKey = openApiRoute.substring(basePath.length);
   const schema = apiDoc.paths[pathKey][method.toLowerCase()];
   const oId = schema['x-eov-operation-id'] || schema['operationId'];
-  const baseName = schema['x-eov-operation-handler'];
+  const handlerName = schema['x-eov-operation-handler'];
 
-  const cacheKey = `${expressRoute}-${method}-${oId}-${baseName}`;
+  const cacheKey = `${expressRoute}-${method}-${oId}-${handlerName}`;
   if (cache[cacheKey]) return cache[cacheKey];
 
-  if (oId && !baseName) {
+  if (oId && !handlerName) {
     throw Error(
       `found x-eov-operation-id for route ${method} - ${expressRoute}]. x-eov-operation-handler required.`,
     );
   }
-  if (!oId && baseName) {
+  if (!oId && handlerName) {
     throw Error(
       `found x-eov-operation-handler for route [${method} - ${expressRoute}]. operationId or x-eov-operation-id required.`,
     );
   }
-  if (oId && baseName && typeof handlersPath === 'string') {
-    const modulePath = path.join(handlersPath, baseName);
-    if (!tmpModules[modulePath]) {
-      tmpModules[modulePath] = require(modulePath);
-    }
 
-    const handler = tmpModules[modulePath][oId] || tmpModules[modulePath].default[oId] || tmpModules[modulePath].default;
+  const isHandlerPath = !!handlersPath && (typeof handlersPath === 'string' || handlersPath instanceof URL);
+  if (oId && handlerName && isHandlerPath) {
+    const modulePath = typeof handlersPath === 'string'
+      ? path.join(handlersPath, handlerName)
+      : path.join(fileURLToPath(handlersPath), handlerName);
+    const importedModule = typeof handlersPath === 'string'
+      ? require(modulePath)
+      : await dynamicImport(pathToFileURL(modulePath).toString());
+
+    const handler = importedModule[oId] || importedModule.default?.[oId] || importedModule.default;
 
     if (!handler) {
       throw Error(

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -17,27 +17,27 @@ export async function defaultResolver(
   const pathKey = openApiRoute.substring(basePath.length);
   const schema = apiDoc.paths[pathKey][method.toLowerCase()];
   const oId = schema['x-eov-operation-id'] || schema['operationId'];
-  const handlerName = schema['x-eov-operation-handler'];
+  const baseName = schema['x-eov-operation-handler'];
 
-  const cacheKey = `${expressRoute}-${method}-${oId}-${handlerName}`;
+  const cacheKey = `${expressRoute}-${method}-${oId}-${baseName}`;
   if (cache[cacheKey]) return cache[cacheKey];
 
-  if (oId && !handlerName) {
+  if (oId && !baseName) {
     throw Error(
       `found x-eov-operation-id for route ${method} - ${expressRoute}]. x-eov-operation-handler required.`,
     );
   }
-  if (!oId && handlerName) {
+  if (!oId && baseName) {
     throw Error(
       `found x-eov-operation-handler for route [${method} - ${expressRoute}]. operationId or x-eov-operation-id required.`,
     );
   }
 
-  const isHandlerPath = !!handlersPath && (typeof handlersPath === 'string' || handlersPath instanceof URL);
-  if (oId && handlerName && isHandlerPath) {
+  const hasHandlerPath = typeof handlersPath === 'string' || handlersPath instanceof URL;
+  if (oId && baseName && hasHandlerPath) {
     const modulePath = typeof handlersPath === 'string'
-      ? path.join(handlersPath, handlerName)
-      : path.join(fileURLToPath(handlersPath), handlerName);
+      ? path.join(handlersPath, baseName)
+      : path.join(fileURLToPath(handlersPath), baseName);
     const importedModule = typeof handlersPath === 'string'
       ? require(modulePath)
       : await dynamicImport(pathToFileURL(modulePath).toString());


### PR DESCRIPTION
Make the default request handler resolver work in ESM projects by allowing a URL value for `options.operationHandlers`. If a URL is passed, then a dynamic import will be used to load handler modules. If a string is passed, then `require()` will be used.

Existing projects should not be adversely affected by this change. The assignment of a `URL` value to `options.operationHandlers` would be the indicator that a user wants to opt-in to this new import handling.

Fixes #660
Fixes #838

### Notice

Because this project uses `moduleResolution:node` in `tsconfig.json`, it's not possible to write `async import(...)` directly in code. It has to be obscured so that the compiler does not replace it with `require()`. Hence, there is a very obvious HACK! in this PR that obscures `import()` via `Function('x', 'return import(x)')` (it's very similar to `eval('import(...)')`).

This hack will probably sink this PR, but I figured I'd post it at least as a proof of concept. Ideally, the module resolution for tsconfig would be updated to `Node16`, but that brings its own issues since `resolveJsonModule:true` would no longer work. Fix one issue, introduce another...

### Usage example

```ts
import {fileURLToPath, pathToFileURL} from 'node:url';
import path from 'node:path';

const __dirname = path.dirname(fileURLToPath(import.meta.url));
const handlersPath = path.join(__dirname, '../path/to/my-routes');

const eov = OpenApiValidator.middleware({
  operationHandlers: pathToFileURL(handlersPath),
  // <rest of configuration>
});
app.use(eov);
```

When defining `x-eov-operation-handler` in schemas, include the file extension on the module name. For example:

```jsonc
{
  "get": {
    "summary": "Get thing",
    "x-eov-operation-id": "getThing",
    "x-eov-operation-handler": "things.js", // <-- include file extension
    "responses": {
```