### PR TITLE
add ajv keywords

### DIFF
--- a/src/framework/ajv/options.ts
+++ b/src/framework/ajv/options.ts
@@ -44,7 +44,7 @@ export class AjvOptions {
   }
 
   private baseOptions(): Options {
-    const { coerceTypes, formats, validateFormats, serDes, ajvFormats } =
+    const { coerceTypes, formats, validateFormats, serDes, ajvFormats, ajvKeywords } =
       this.options;
     const serDesMap = {};
     for (const serDesObject of serDes) {
@@ -73,6 +73,7 @@ export class AjvOptions {
       formats,
       serDesMap,
       ajvFormats,
+      keywords: ajvKeywords
     };
 
     return options;

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -149,6 +149,7 @@ export interface OpenApiValidatorOpts {
   unknownFormats?: true | string[] | 'ignore';
   serDes?: SerDes[];
   formats?: Format[] | Record<string, ajv.Format>;
+  ajvKeywords?: ajv.Vocabulary
   ajvFormats?: FormatsPluginOptions;
   fileUploader?: boolean | multer.Options;
   multerOpts?: multer.Options;


### PR DESCRIPTION
As per [this issue](https://github.com/cdimascio/express-openapi-validator/issues/927) we are in need of custom keywords. 

This pull request adds the support for that.

As the Ajv constructor already supports receiving keywords as options only the declaration for this ajvKeyword type is needed. 
