### PR TITLE
Stripped query params for req.url branch arm

### DIFF
--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -71,7 +71,7 @@ export function applyOpenApiMetadata(
     req: OpenApiRequest,
     useRequestUrl: boolean,
   ): OpenApiRequestMetadata {
-    const path = useRequestUrl ? req.url : req.originalUrl.split('?')[0];
+    const path = useRequestUrl ? req.url.split('?')[0] : req.originalUrl.split('?')[0];
     const method = req.method;
     const routeEntries = Object.entries(openApiContext.expressRouteMap);
     for (const [expressRoute, methods] of routeEntries) {


### PR DESCRIPTION
Fixes #941 By removing the query parameters for the `req.url` branch when `useRequestUrl` is true. Validated fix with local schema (as described in issue).