### PR TITLE
fix: add cookie support for HTTP bearer authentication

### DIFF
--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -24,21 +24,31 @@ interface SecurityHandlerResult {
   error?: string;
 }
 
-function extractErrorsFromResults(results: (SecurityHandlerResult | SecurityHandlerResult[])[]) {
-  return results.map(result => {
-    if (Array.isArray(result)) {
-      return result.map(it => it).filter(it => !it.success);
-    }
-    return [result].filter(it => !it.success);
-  }).flatMap(it => [...it]);
+function extractErrorsFromResults(
+  results: (SecurityHandlerResult | SecurityHandlerResult[])[],
+) {
+  return results
+    .map((result) => {
+      if (Array.isArray(result)) {
+        return result.map((it) => it).filter((it) => !it.success);
+      }
+      return [result].filter((it) => !it.success);
+    })
+    .flatMap((it) => [...it]);
 }
 
 function didAllSecurityRequirementsPass(results: SecurityHandlerResult[]) {
-  return results.every(it => it.success);
+  return results.every((it) => it.success);
 }
 
-function didOneSchemaPassValidation(results: (SecurityHandlerResult | SecurityHandlerResult[])[]) {
-  return results.some(result => Array.isArray(result) ? didAllSecurityRequirementsPass(result) : result.success);
+function didOneSchemaPassValidation(
+  results: (SecurityHandlerResult | SecurityHandlerResult[])[],
+) {
+  return results.some((result) =>
+    Array.isArray(result)
+      ? didAllSecurityRequirementsPass(result)
+      : result.success,
+  );
 }
 
 export function security(
@@ -86,8 +96,8 @@ export function security(
       if (success) {
         next();
       } else {
-        const errors = extractErrorsFromResults(results)
-        throw errors[0]
+        const errors = extractErrorsFromResults(results);
+        throw errors[0];
       }
     } catch (e) {
       const message = e?.error?.message || 'unauthorized';
@@ -232,20 +242,20 @@ class AuthValidator {
       const authHeader =
         req.headers['authorization'] &&
         req.headers['authorization'].toLowerCase();
-        const authCookie = req.cookies[scheme.name] || req.signedCookies?.[scheme.name]; 
-
-      if (!authHeader && !authCookie) {
-        throw Error(`Authorization header or cookie required`);
-      }
+      const authCookie =
+        req.cookies[scheme.name] || req.signedCookies?.[scheme.name];
 
       const type = scheme.scheme && scheme.scheme.toLowerCase();
       if (type === 'bearer') {
         if (authHeader && !authHeader.includes('bearer')) {
-            throw Error(`Authorization header with scheme 'Bearer' required`);
+          throw Error(`Authorization header with scheme 'Bearer' required`);
         }
-
-        if (!authHeader && authCookie === undefined) {
-            throw Error(`Bearer token required in authorization header or cookie`);
+        if (!authHeader && !authCookie) {
+          if (scheme.in === 'cookie') {
+            throw Error(`Cookie authentication required`);
+          } else {
+            throw Error(`Authorization header required`);
+          }
         }
       }
 

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -31,6 +31,7 @@ function extractErrorsFromResults(results: (SecurityHandlerResult | SecurityHand
     }
     return [result].filter(it => !it.success);
   }).flatMap(it => [...it]);
+}
 
 function didAllSecurityRequirementsPass(results: SecurityHandlerResult[]) {
   return results.every(it => it.success);
@@ -38,6 +39,7 @@ function didAllSecurityRequirementsPass(results: SecurityHandlerResult[]) {
 
 function didOneSchemaPassValidation(results: (SecurityHandlerResult | SecurityHandlerResult[])[]) {
   return results.some(result => Array.isArray(result) ? didAllSecurityRequirementsPass(result) : result.success);
+}
 
 export function security(
   apiDoc: OpenAPIV3.Document,
@@ -84,8 +86,8 @@ export function security(
       if (success) {
         next();
       } else {
-        const errors = extractErrorsFromResults(results)
-        throw errors[0]
+        const errors = extractErrorsFromResults(results);
+        throw errors[0];
       }
     } catch (e) {
       const message = e?.error?.message || 'unauthorized';

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -234,12 +234,13 @@ class AuthValidator {
         req.headers['authorization'].toLowerCase();
       const authCookie =
         req.cookies[scheme.name] || req.signedCookies?.[scheme.name];
-
+  
       const type = scheme.scheme && scheme.scheme.toLowerCase();
       if (type === 'bearer') {
         if (authHeader && !authHeader.includes('bearer')) {
           throw Error(`Authorization header with scheme 'Bearer' required`);
         }
+        
         if (!authHeader && !authCookie) {
           if (scheme.in === 'cookie') {
             throw Error(`Cookie authentication required`);
@@ -248,9 +249,14 @@ class AuthValidator {
           }
         }
       }
-
-      if (type === 'basic' && !authHeader.includes('basic')) {
-        throw Error(`Authorization header with scheme 'Basic' required`);
+  
+      if (type === 'basic') {
+        if (!authHeader) {
+          throw Error(`Authorization header required`);
+        }
+        if (!authHeader.includes('basic')) {
+          throw Error(`Authorization header with scheme 'Basic' required`);
+        }
       }
     }
   }

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -24,32 +24,20 @@ interface SecurityHandlerResult {
   error?: string;
 }
 
-function extractErrorsFromResults(
-  results: (SecurityHandlerResult | SecurityHandlerResult[])[],
-) {
-  return results
-    .map((result) => {
-      if (Array.isArray(result)) {
-        return result.map((it) => it).filter((it) => !it.success);
-      }
-      return [result].filter((it) => !it.success);
-    })
-    .flatMap((it) => [...it]);
-}
+function extractErrorsFromResults(results: (SecurityHandlerResult | SecurityHandlerResult[])[]) {
+  return results.map(result => {
+    if (Array.isArray(result)) {
+      return result.map(it => it).filter(it => !it.success);
+    }
+    return [result].filter(it => !it.success);
+  }).flatMap(it => [...it]);
 
 function didAllSecurityRequirementsPass(results: SecurityHandlerResult[]) {
-  return results.every((it) => it.success);
+  return results.every(it => it.success);
 }
 
-function didOneSchemaPassValidation(
-  results: (SecurityHandlerResult | SecurityHandlerResult[])[],
-) {
-  return results.some((result) =>
-    Array.isArray(result)
-      ? didAllSecurityRequirementsPass(result)
-      : result.success,
-  );
-}
+function didOneSchemaPassValidation(results: (SecurityHandlerResult | SecurityHandlerResult[])[]) {
+  return results.some(result => Array.isArray(result) ? didAllSecurityRequirementsPass(result) : result.success);
 
 export function security(
   apiDoc: OpenAPIV3.Document,
@@ -96,8 +84,8 @@ export function security(
       if (success) {
         next();
       } else {
-        const errors = extractErrorsFromResults(results);
-        throw errors[0];
+        const errors = extractErrorsFromResults(results)
+        throw errors[0]
       }
     } catch (e) {
       const message = e?.error?.message || 'unauthorized';

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -232,14 +232,21 @@ class AuthValidator {
       const authHeader =
         req.headers['authorization'] &&
         req.headers['authorization'].toLowerCase();
+        const authCookie = req.cookies[scheme.name] || req.signedCookies?.[scheme.name]; 
 
-      if (!authHeader) {
-        throw Error(`Authorization header required`);
+      if (!authHeader && !authCookie) {
+        throw Error(`Authorization header or cookie required`);
       }
 
       const type = scheme.scheme && scheme.scheme.toLowerCase();
-      if (type === 'bearer' && !authHeader.includes('bearer')) {
-        throw Error(`Authorization header with scheme 'Bearer' required`);
+      if (type === 'bearer') {
+        if (authHeader && !authHeader.includes('bearer')) {
+            throw Error(`Authorization header with scheme 'Bearer' required`);
+        }
+
+        if (!authHeader && authCookie === undefined) {
+            throw Error(`Bearer token required in authorization header or cookie`);
+        }
       }
 
       if (type === 'basic' && !authHeader.includes('basic')) {


### PR DESCRIPTION
### Overview
In my project, we use HTTP-only cookies exclusively for sending authentication tokens, and the Authorization header is not required. I encountered issues with the current `validateHttp()` implementation because it only validates tokens in the Authorization header. To address this, I made a minor adjustment to check for tokens in both the Authorization header and cookies.

### Changes
- Updated `validateHttp()` to look for bearer tokens in cookies, in addition to the Authorization header.

### Reason for Change
Typically, HTTP authentication relies on the Authorization header, as token-based authentication often uses headers according to REST API standards. However, when using HTTP-only cookies—especially in setups that employ CSRF protection—this is a common approach for managing tokens.

I’ve made these changes to provide more flexibility for projects that use cookies for authentication. I wanted to propose this adjustment and get feedback on whether this approach aligns with broader use cases or if there are other considerations.

I didn't even touch the associated test code for quick post-application feedback!

Let me know your thoughts on this modification!
