### PR TITLE
Change AJV allErrors default and support user setting

### DIFF
--- a/src/framework/ajv/index.ts
+++ b/src/framework/ajv/index.ts
@@ -32,7 +32,6 @@ function createAjv(
   const { ajvFormats, ...ajvOptions } = options;
   const ajv = new AjvDraft4({
     ...ajvOptions,
-    allErrors: true,
     formats: formats,
   });
 

--- a/src/framework/ajv/options.ts
+++ b/src/framework/ajv/options.ts
@@ -45,8 +45,14 @@ export class AjvOptions {
   }
 
   private baseOptions(): Options {
-    const { coerceTypes, formats, validateFormats, serDes, allErrors, ajvFormats } =
-      this.options;
+    const {
+      coerceTypes,
+      formats,
+      validateFormats,
+      serDes,
+      allErrors,
+      ajvFormats,
+    } = this.options;
     const serDesMap = {};
     for (const serDesObject of serDes) {
       if (!serDesMap[serDesObject.format]) {
@@ -70,10 +76,10 @@ export class AjvOptions {
       coerceTypes,
       useDefaults: true,
       removeAdditional: false,
-      validateFormats: validateFormats,
+      validateFormats,
       formats,
       serDesMap,
-      allErrors: allErrors === undefined || allErrors,
+      allErrors,
       ajvFormats,
     };
 

--- a/src/framework/ajv/options.ts
+++ b/src/framework/ajv/options.ts
@@ -17,11 +17,12 @@ export class AjvOptions {
   }
 
   get response(): Options {
-    const { coerceTypes, removeAdditional } = <ValidateResponseOpts>(
+    const { allErrors, coerceTypes, removeAdditional } = <ValidateResponseOpts>(
       this.options.validateResponses
     );
     return {
       ...this.baseOptions(),
+      allErrors,
       useDefaults: false,
       coerceTypes,
       removeAdditional,
@@ -29,11 +30,12 @@ export class AjvOptions {
   }
 
   get request(): RequestValidatorOptions {
-    const { allowUnknownQueryParameters, coerceTypes, removeAdditional } = <
+    const { allErrors, allowUnknownQueryParameters, coerceTypes, removeAdditional } = <
       ValidateRequestOpts
     >this.options.validateRequests;
     return {
       ...this.baseOptions(),
+      allErrors,
       allowUnknownQueryParameters,
       coerceTypes,
       removeAdditional,
@@ -50,7 +52,6 @@ export class AjvOptions {
       formats,
       validateFormats,
       serDes,
-      allErrors,
       ajvFormats,
     } = this.options;
     const serDesMap = {};
@@ -79,7 +80,6 @@ export class AjvOptions {
       validateFormats,
       formats,
       serDesMap,
-      allErrors,
       ajvFormats,
     };
 

--- a/src/framework/ajv/options.ts
+++ b/src/framework/ajv/options.ts
@@ -11,6 +11,7 @@ export class AjvOptions {
   constructor(options: NormalizedOpenApiValidatorOpts) {
     this.options = options;
   }
+
   get preprocessor(): Options {
     return this.baseOptions();
   }
@@ -44,7 +45,7 @@ export class AjvOptions {
   }
 
   private baseOptions(): Options {
-    const { coerceTypes, formats, validateFormats, serDes, ajvFormats } =
+    const { coerceTypes, formats, validateFormats, serDes, allErrors, ajvFormats } =
       this.options;
     const serDesMap = {};
     for (const serDesObject of serDes) {
@@ -72,6 +73,7 @@ export class AjvOptions {
       validateFormats: validateFormats,
       formats,
       serDesMap,
+      allErrors: allErrors === undefined || allErrors,
       ajvFormats,
     };
 

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -150,6 +150,13 @@ export interface OpenApiValidatorOpts {
   serDes?: SerDes[];
   formats?: Format[] | Record<string, ajv.Format>;
   ajvFormats?: FormatsPluginOptions;
+  /**
+   * Whether AJV should check all rules and collect all errors or return after the first error.
+   *
+   * The default is `true`. This should be set to `false` in production. See [AJV: Security risks of
+   * trusted schemas](https://ajv.js.org/security.html#security-risks-of-trusted-schemas).
+   */
+  allErrors?: boolean;
   fileUploader?: boolean | multer.Options;
   multerOpts?: multer.Options;
   $refParser?: {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -153,8 +153,8 @@ export interface OpenApiValidatorOpts {
   /**
    * Whether AJV should check all rules and collect all errors or return after the first error.
    *
-   * The default is `true`. This should be set to `false` in production. See [AJV: Security risks of
-   * trusted schemas](https://ajv.js.org/security.html#security-risks-of-trusted-schemas).
+   * This should not be set to `true` in production. See [AJV: Security risks of trusted
+   * schemas](https://ajv.js.org/security.html#security-risks-of-trusted-schemas).
    */
   allErrors?: boolean;
   fileUploader?: boolean | multer.Options;

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -47,12 +47,26 @@ export interface Options extends ajv.Options {
 export interface RequestValidatorOptions extends Options, ValidateRequestOpts { }
 
 export type ValidateRequestOpts = {
+  /**
+   * Whether AJV should check all rules and collect all errors or return after the first error.
+   *
+   * This should not be set to `true` in production. See [AJV: Security risks of trusted
+   * schemas](https://ajv.js.org/security.html#security-risks-of-trusted-schemas).
+   */
+  allErrors?: boolean;
   allowUnknownQueryParameters?: boolean;
   coerceTypes?: boolean | 'array';
   removeAdditional?: boolean | 'all' | 'failing';
 };
 
 export type ValidateResponseOpts = {
+  /**
+   * Whether AJV should check all rules and collect all errors or return after the first error.
+   *
+   * This should not be set to `true` in production. See [AJV: Security risks of trusted
+   * schemas](https://ajv.js.org/security.html#security-risks-of-trusted-schemas).
+   */
+  allErrors?: boolean;
   removeAdditional?: boolean | 'all' | 'failing';
   coerceTypes?: boolean | 'array';
   onError?: (err: InternalServerError, json: any, req: Request) => void;
@@ -150,13 +164,6 @@ export interface OpenApiValidatorOpts {
   serDes?: SerDes[];
   formats?: Format[] | Record<string, ajv.Format>;
   ajvFormats?: FormatsPluginOptions;
-  /**
-   * Whether AJV should check all rules and collect all errors or return after the first error.
-   *
-   * This should not be set to `true` in production. See [AJV: Security risks of trusted
-   * schemas](https://ajv.js.org/security.html#security-risks-of-trusted-schemas).
-   */
-  allErrors?: boolean;
   fileUploader?: boolean | multer.Options;
   multerOpts?: multer.Options;
   $refParser?: {

--- a/test/699.spec.ts
+++ b/test/699.spec.ts
@@ -182,7 +182,6 @@ describe('699 serialize response components only', () => {
       3005,
       (app) => {
         app.get([`${app.basePath}/users/:id?`], (req, res) => {
-          debugger;
           if (typeof req.params.id !== 'string') {
             throw new Error("Should be not be deserialized to ObjectId object");
           }

--- a/test/881.spec.ts
+++ b/test/881.spec.ts
@@ -51,6 +51,7 @@ function createServer() {
       OpenApiValidator.middleware({
         apiSpec,
         validateResponses: true,
+        allErrors: true,
       }),
     );
 

--- a/test/881.spec.ts
+++ b/test/881.spec.ts
@@ -50,8 +50,10 @@ function createServer() {
     app.use(
       OpenApiValidator.middleware({
         apiSpec,
+        validateRequests: {
+          allErrors: true,
+        },
         validateResponses: true,
-        allErrors: true,
       }),
     );
 

--- a/test/additional.props.spec.ts
+++ b/test/additional.props.spec.ts
@@ -15,7 +15,7 @@ describe(packageJson.name, () => {
       'resources',
       'additional.properties.yaml',
     );
-    app = await createApp({ apiSpec }, 3005, (app) =>
+    app = await createApp({ apiSpec, allErrors: true }, 3005, (app) =>
       app.use(
         `${app.basePath}/additional_props`,
         express

--- a/test/additional.props.spec.ts
+++ b/test/additional.props.spec.ts
@@ -15,14 +15,22 @@ describe(packageJson.name, () => {
       'resources',
       'additional.properties.yaml',
     );
-    app = await createApp({ apiSpec, allErrors: true }, 3005, (app) =>
-      app.use(
-        `${app.basePath}/additional_props`,
-        express
-          .Router()
-          .post(`/false`, (req, res) => res.json(req.body))
-          .post(`/true`, (req, res) => res.json(req.body)),
-      ),
+    app = await createApp(
+      {
+        apiSpec,
+        validateRequests: {
+          allErrors: true,
+        },
+      },
+      3005,
+      (app) =>
+        app.use(
+          `${app.basePath}/additional_props`,
+          express
+            .Router()
+            .post(`/false`, (req, res) => res.json(req.body))
+            .post(`/true`, (req, res) => res.json(req.body)),
+        ),
     );
   });
 

--- a/test/ajv.options.spec.ts
+++ b/test/ajv.options.spec.ts
@@ -10,8 +10,8 @@ describe('AjvOptions', () => {
     apiSpec: './spec',
     validateApiSpec: false,
     validateRequests: {
-        allowUnknownQueryParameters: false,
-        coerceTypes: false,
+      allowUnknownQueryParameters: false,
+      coerceTypes: false,
     },
     validateResponses: {
       coerceTypes: false,
@@ -44,7 +44,7 @@ describe('AjvOptions', () => {
     expect(options.validateSchema).to.be.false;
   });
 
-  it('should not validate schema for multipar since schema is validated on startup', async () => {
+  it('should not validate schema for multipart since schema is validated on startup', async () => {
     const ajv = new AjvOptions(baseOptions);
     const options = ajv.multipart;
     expect(options.validateSchema).to.be.false;
@@ -60,7 +60,7 @@ describe('AjvOptions', () => {
         },
       ],
     });
-    const options = ajv.multipart;
+    const options = ajv.preprocessor;
     expect(options.serDesMap['custom-1']).has.property('deserialize');
     expect(options.serDesMap['custom-1']).does.not.have.property('serialize');
   });
@@ -75,7 +75,7 @@ describe('AjvOptions', () => {
         },
       ],
     });
-    const options = ajv.multipart;
+    const options = ajv.preprocessor;
     expect(options.serDesMap).has.property('custom-1');
     expect(options.serDesMap['custom-1']).has.property('serialize');
     expect(options.serDesMap['custom-1']).does.not.have.property('deserialize');
@@ -92,7 +92,7 @@ describe('AjvOptions', () => {
         },
       ],
     });
-    const options = ajv.multipart;
+    const options = ajv.preprocessor;
     expect(options.serDesMap).has.property('custom-1');
     expect(options.serDesMap['custom-1']).has.property('serialize');
     expect(options.serDesMap['custom-1']).has.property('deserialize');
@@ -116,9 +116,26 @@ describe('AjvOptions', () => {
         },
       ],
     });
-    const options = ajv.multipart;
+    const options = ajv.preprocessor;
     expect(options.serDesMap).has.property('custom-1');
     expect(options.serDesMap['custom-1']).has.property('serialize');
     expect(options.serDesMap['custom-1']).has.property('deserialize');
+  });
+
+  it('should default to allErrors', () => {
+    const ajv = new AjvOptions({
+      ...baseOptions,
+    });
+    const options = ajv.preprocessor;
+    expect(options.allErrors).to.be.true;
+  });
+
+  it('should respect user allErrors setting', () => {
+    const ajv = new AjvOptions({
+      ...baseOptions,
+      allErrors: false,
+    });
+    const options = ajv.preprocessor;
+    expect(options.allErrors).to.be.false;
   });
 });

--- a/test/ajv.options.spec.ts
+++ b/test/ajv.options.spec.ts
@@ -122,20 +122,20 @@ describe('AjvOptions', () => {
     expect(options.serDesMap['custom-1']).has.property('deserialize');
   });
 
-  it('should default to allErrors', () => {
+  it('should default to not setting allErrors', () => {
     const ajv = new AjvOptions({
       ...baseOptions,
     });
     const options = ajv.preprocessor;
-    expect(options.allErrors).to.be.true;
+    expect(options.allErrors).to.be.undefined;
   });
 
   it('should respect user allErrors setting', () => {
     const ajv = new AjvOptions({
       ...baseOptions,
-      allErrors: false,
+      allErrors: true,
     });
     const options = ajv.preprocessor;
-    expect(options.allErrors).to.be.false;
+    expect(options.allErrors).to.be.true;
   });
 });

--- a/test/ajv.options.spec.ts
+++ b/test/ajv.options.spec.ts
@@ -121,21 +121,4 @@ describe('AjvOptions', () => {
     expect(options.serDesMap['custom-1']).has.property('serialize');
     expect(options.serDesMap['custom-1']).has.property('deserialize');
   });
-
-  it('should default to not setting allErrors', () => {
-    const ajv = new AjvOptions({
-      ...baseOptions,
-    });
-    const options = ajv.preprocessor;
-    expect(options.allErrors).to.be.undefined;
-  });
-
-  it('should respect user allErrors setting', () => {
-    const ajv = new AjvOptions({
-      ...baseOptions,
-      allErrors: true,
-    });
-    const options = ajv.preprocessor;
-    expect(options.allErrors).to.be.true;
-  });
 });

--- a/test/all-errors.spec.ts
+++ b/test/all-errors.spec.ts
@@ -20,7 +20,7 @@ describe('request body validation with and without allErrors', () => {
       {
         apiSpec,
         formats: { 'starts-with-b': (v) => /^b/i.test(v) },
-        // allErrors is set to true when undefined
+        allErrors: true,
       },
       3005,
       defineRoutes,
@@ -31,7 +31,6 @@ describe('request body validation with and without allErrors', () => {
       {
         apiSpec,
         formats: { 'starts-with-b': (v) => /^b/i.test(v) },
-        allErrors: false,
       },
       3006,
       defineRoutes,

--- a/test/all-errors.spec.ts
+++ b/test/all-errors.spec.ts
@@ -1,0 +1,73 @@
+import * as path from 'path';
+import * as request from 'supertest';
+import { expect } from 'chai';
+import { createApp } from './common/app';
+
+describe('request body validation with and without allErrors', () => {
+  let allErrorsApp;
+  let notAllErrorsApp;
+
+  const defineRoutes = (app) => {
+    app.post(`${app.basePath}/persons`, (req, res) => {
+      res.send({ success: true });
+    });
+  };
+
+  before(async () => {
+    const apiSpec = path.join('test', 'resources', 'multiple-validations.yaml');
+
+    allErrorsApp = await createApp(
+      {
+        apiSpec,
+        formats: { 'starts-with-b': (v) => /^b/i.test(v) },
+        // allErrors is set to true when undefined
+      },
+      3005,
+      defineRoutes,
+      true,
+    );
+
+    notAllErrorsApp = await createApp(
+      {
+        apiSpec,
+        formats: { 'starts-with-b': (v) => /^b/i.test(v) },
+        allErrors: false,
+      },
+      3006,
+      defineRoutes,
+      true,
+    );
+  });
+
+  after(() => {
+    allErrorsApp.server.close();
+    notAllErrorsApp.server.close();
+  });
+
+  it('should return 200 if short b-name is provided', async () =>
+    request(allErrorsApp)
+      .post(`${allErrorsApp.basePath}/persons`)
+      .set('content-type', 'application/json')
+      .send({ bname: 'Bob' })
+      .expect(200));
+
+  it('should include all validation errors when allErrors=true', async () =>
+    request(allErrorsApp)
+      .post(`${allErrorsApp.basePath}/persons`)
+      .set('content-type', 'application/json')
+      .send({ bname: 'Maximillian' })
+      .expect(400)
+      .then((res) => {
+        expect(res.body.errors.length).to.equal(2);
+      }));
+
+  it('should include only first validation error when allErrors=false', async () =>
+    request(notAllErrorsApp)
+      .post(`${notAllErrorsApp.basePath}/persons`)
+      .set('content-type', 'application/json')
+      .send({ bname: 'Maximillian' })
+      .expect(400)
+      .then((res) => {
+        expect(res.body.errors.length).to.equal(1);
+      }));
+});

--- a/test/all.of.spec.ts
+++ b/test/all.of.spec.ts
@@ -11,11 +11,19 @@ describe(packageJson.name, () => {
   before(async () => {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'all.of.yaml');
-    app = await createApp({ apiSpec, allErrors: true }, 3005, (app) =>
-      app.use(
-        `${app.basePath}`,
-        express.Router().post(`/all_of`, (req, res) => res.json(req.body)),
-      ),
+    app = await createApp(
+      {
+        apiSpec,
+        validateRequests: {
+          allErrors: true,
+        },
+      },
+      3005,
+      (app) =>
+        app.use(
+          `${app.basePath}`,
+          express.Router().post(`/all_of`, (req, res) => res.json(req.body)),
+        ),
     );
   });
 

--- a/test/all.of.spec.ts
+++ b/test/all.of.spec.ts
@@ -11,7 +11,7 @@ describe(packageJson.name, () => {
   before(async () => {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'all.of.yaml');
-    app = await createApp({ apiSpec }, 3005, (app) =>
+    app = await createApp({ apiSpec, allErrors: true }, 3005, (app) =>
       app.use(
         `${app.basePath}`,
         express.Router().post(`/all_of`, (req, res) => res.json(req.body)),

--- a/test/empty.servers.spec.ts
+++ b/test/empty.servers.spec.ts
@@ -10,7 +10,7 @@ describe('empty servers', () => {
   before(async () => {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'empty.servers.yaml');
-    app = await createApp({ apiSpec }, 3007, app =>
+    app = await createApp({ apiSpec, allErrors: true }, 3007, app =>
       app.use(
         ``,
         express

--- a/test/empty.servers.spec.ts
+++ b/test/empty.servers.spec.ts
@@ -10,13 +10,19 @@ describe('empty servers', () => {
   before(async () => {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'empty.servers.yaml');
-    app = await createApp({ apiSpec, allErrors: true }, 3007, app =>
-      app.use(
-        ``,
-        express
-          .Router()
-          .get(`/pets`, (req, res) => res.json(req.body)),
-      ),
+    app = await createApp(
+      {
+        apiSpec,
+        validateRequests: {
+          allErrors: true,
+        },
+      },
+      3007,
+      (app) =>
+        app.use(
+          ``,
+          express.Router().get(`/pets`, (req, res) => res.json(req.body)),
+        ),
     );
   });
 
@@ -28,7 +34,7 @@ describe('empty servers', () => {
     request(app)
       .get(`/pets`)
       .expect(400)
-      .then(r => {
+      .then((r) => {
         expect(r.body.errors).to.be.an('array');
         expect(r.body.errors).to.have.length(2);
       }));

--- a/test/multi.spec.spec.ts
+++ b/test/multi.spec.spec.ts
@@ -50,6 +50,7 @@ function createServer() {
     app.use(
       OpenApiValidator.middleware({
         apiSpec,
+        allErrors: true,
       }),
     );
 

--- a/test/multi.spec.spec.ts
+++ b/test/multi.spec.spec.ts
@@ -50,7 +50,9 @@ function createServer() {
     app.use(
       OpenApiValidator.middleware({
         apiSpec,
-        allErrors: true,
+        validateRequests: {
+          allErrors: true,
+        },
       }),
     );
 

--- a/test/multipart.disabled.spec.ts
+++ b/test/multipart.disabled.spec.ts
@@ -9,7 +9,7 @@ describe(packageJson.name, () => {
   let app = null;
   before(async () => {
     const apiSpec = path.join('test', 'resources', 'multipart.yaml');
-    app = await createApp({ apiSpec, fileUploader: false }, 3003, app =>
+    app = await createApp({ apiSpec, allErrors: true, fileUploader: false }, 3003, app =>
       app.use(
         `${app.basePath}`,
         express

--- a/test/multipart.disabled.spec.ts
+++ b/test/multipart.disabled.spec.ts
@@ -9,15 +9,24 @@ describe(packageJson.name, () => {
   let app = null;
   before(async () => {
     const apiSpec = path.join('test', 'resources', 'multipart.yaml');
-    app = await createApp({ apiSpec, allErrors: true, fileUploader: false }, 3003, app =>
-      app.use(
-        `${app.basePath}`,
-        express
-          .Router()
-          .post(`/sample_2`, (req, res) => res.json(req.body))
-          .post(`/sample_1`, (req, res) => res.json(req.body))
-          .get('/range', (req, res) => res.json(req.body)),
-      ),
+    app = await createApp(
+      {
+        apiSpec,
+        fileUploader: false,
+        validateRequests: {
+          allErrors: true,
+        },
+      },
+      3003,
+      (app) =>
+        app.use(
+          `${app.basePath}`,
+          express
+            .Router()
+            .post(`/sample_2`, (req, res) => res.json(req.body))
+            .post(`/sample_1`, (req, res) => res.json(req.body))
+            .get('/range', (req, res) => res.json(req.body)),
+        ),
     );
   });
   after(() => {

--- a/test/openapi.spec.ts
+++ b/test/openapi.spec.ts
@@ -12,8 +12,8 @@ describe(packageJson.name, () => {
     const apiSpecPath = path.join('test', 'resources', 'openapi.yaml');
     const apiSpecJson = require('./resources/openapi.json');
     return Promise.all([
-      createApp({ apiSpec: apiSpecPath }, 3001),
-      createApp({ apiSpec: apiSpecJson }, 3002),
+      createApp({ apiSpec: apiSpecPath, allErrors: true }, 3001),
+      createApp({ apiSpec: apiSpecJson, allErrors: true }, 3002),
     ]).then(([a1, a2]) => {
       apps.push(a1);
       apps.push(a2);

--- a/test/openapi.spec.ts
+++ b/test/openapi.spec.ts
@@ -12,8 +12,24 @@ describe(packageJson.name, () => {
     const apiSpecPath = path.join('test', 'resources', 'openapi.yaml');
     const apiSpecJson = require('./resources/openapi.json');
     return Promise.all([
-      createApp({ apiSpec: apiSpecPath, allErrors: true }, 3001),
-      createApp({ apiSpec: apiSpecJson, allErrors: true }, 3002),
+      createApp(
+        {
+          apiSpec: apiSpecPath,
+          validateRequests: {
+            allErrors: true,
+          },
+        },
+        3001,
+      ),
+      createApp(
+        {
+          apiSpec: apiSpecJson,
+          validateRequests: {
+            allErrors: true,
+          },
+        },
+        3002,
+      ),
     ]).then(([a1, a2]) => {
       apps.push(a1);
       apps.push(a2);

--- a/test/path.level.parameters.spec.ts
+++ b/test/path.level.parameters.spec.ts
@@ -15,13 +15,21 @@ describe(packageJson.name, () => {
       'resources',
       'path.level.parameters.yaml',
     );
-    app = await createApp({ apiSpec, allErrors: true }, 3005, app =>
-      app.use(
-        `${app.basePath}`,
-        express
-          .Router()
-          .get(`/path_level_parameters`, (_req, res) => res.send()),
-      ),
+    app = await createApp(
+      {
+        apiSpec,
+        validateRequests: {
+          allErrors: true,
+        },
+      },
+      3005,
+      (app) =>
+        app.use(
+          `${app.basePath}`,
+          express
+            .Router()
+            .get(`/path_level_parameters`, (_req, res) => res.send()),
+        ),
     );
   });
 

--- a/test/path.level.parameters.spec.ts
+++ b/test/path.level.parameters.spec.ts
@@ -15,7 +15,7 @@ describe(packageJson.name, () => {
       'resources',
       'path.level.parameters.yaml',
     );
-    app = await createApp({ apiSpec }, 3005, app =>
+    app = await createApp({ apiSpec, allErrors: true }, 3005, app =>
       app.use(
         `${app.basePath}`,
         express

--- a/test/request.bodies.ref.spec.ts
+++ b/test/request.bodies.ref.spec.ts
@@ -13,6 +13,7 @@ describe('request bodies', () => {
     app = await createApp(
       {
         apiSpec,
+        allErrors: true,
         validateResponses: true,
         unknownFormats: ['phone-number'],
       },

--- a/test/request.bodies.ref.spec.ts
+++ b/test/request.bodies.ref.spec.ts
@@ -13,7 +13,9 @@ describe('request bodies', () => {
     app = await createApp(
       {
         apiSpec,
-        allErrors: true,
+        validateRequests: {
+          allErrors: true,
+        },
         validateResponses: true,
         unknownFormats: ['phone-number'],
       },

--- a/test/resources/multiple-validations.yaml
+++ b/test/resources/multiple-validations.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.1
+info:
+  title: Multiple validations for allErrors check
+  version: 1.0.0
+servers:
+  - url: /v1
+paths:
+  /persons:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Person"
+      responses:
+        200:
+          description: Success
+
+components:
+  schemas:
+    Person:
+      required:
+        - bname
+      type: object
+      properties:
+        bname:
+          type: string
+          format: starts-with-b
+          maxLength: 10

--- a/test/resources/multiple-validations.yaml
+++ b/test/resources/multiple-validations.yaml
@@ -15,6 +15,30 @@ paths:
       responses:
         200:
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                properties:
+                  success:
+                    type: boolean
+
+    get:
+      parameters:
+        - in: query
+          name: bname
+          schema:
+            type: string
+          required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
 
 components:
   schemas:

--- a/test/write.only.spec.ts
+++ b/test/write.only.spec.ts
@@ -10,38 +10,47 @@ describe(packageJson.name, () => {
   before(async () => {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'write.only.yaml');
-    app = await createApp({ apiSpec, allErrors: true, validateResponses: true }, 3005, (app) =>
-      app
-        .post(`${app.basePath}/products/inlined`, (req, res) => {
-          const body = req.body;
-          const excludeWriteOnly = req.query.exclude_write_only;
-          if (excludeWriteOnly) {
-            delete body.role;
-          }
-          res.json({
-            ...body,
-          });
-        })
-        .post(`${app.basePath}/products/nested`, (req, res) => {
-          const body = req.body;
-          const excludeWriteOnly = req.query.exclude_write_only;
-          body.id = 'test';
-          body.created_at = new Date().toISOString();
-          body.reviews = body.reviews.map((r) => ({
-            ...(excludeWriteOnly ? {} : { role_x: 'admin' }),
-            rating: r.rating ?? 2,
-          }));
+    app = await createApp(
+      {
+        apiSpec,
+        validateRequests: {
+          allErrors: true,
+        },
+        validateResponses: true,
+      },
+      3005,
+      (app) =>
+        app
+          .post(`${app.basePath}/products/inlined`, (req, res) => {
+            const body = req.body;
+            const excludeWriteOnly = req.query.exclude_write_only;
+            if (excludeWriteOnly) {
+              delete body.role;
+            }
+            res.json({
+              ...body,
+            });
+          })
+          .post(`${app.basePath}/products/nested`, (req, res) => {
+            const body = req.body;
+            const excludeWriteOnly = req.query.exclude_write_only;
+            body.id = 'test';
+            body.created_at = new Date().toISOString();
+            body.reviews = body.reviews.map((r) => ({
+              ...(excludeWriteOnly ? {} : { role_x: 'admin' }),
+              rating: r.rating ?? 2,
+            }));
 
-          if (excludeWriteOnly) {
-            delete body.role;
-            delete body.password;
-          }
-          res.json({
-            // id: 'xxxxx',
-            // created_at: '2024-02-09T17:32:28Z',
-            ...body,
-          });
-        }),
+            if (excludeWriteOnly) {
+              delete body.role;
+              delete body.password;
+            }
+            res.json({
+              // id: 'xxxxx',
+              // created_at: '2024-02-09T17:32:28Z',
+              ...body,
+            });
+          }),
     );
   });
 

--- a/test/write.only.spec.ts
+++ b/test/write.only.spec.ts
@@ -10,7 +10,7 @@ describe(packageJson.name, () => {
   before(async () => {
     // Set up the express app
     const apiSpec = path.join('test', 'resources', 'write.only.yaml');
-    app = await createApp({ apiSpec, validateResponses: true }, 3005, (app) =>
+    app = await createApp({ apiSpec, allErrors: true, validateResponses: true }, 3005, (app) =>
       app
         .post(`${app.basePath}/products/inlined`, (req, res) => {
           const body = req.body;


### PR DESCRIPTION
**BREAKING CHANGE**: Request and response validation stops after the first failure. Only one error will be reported even when multiple may exist. This follows best practices from AJV:
- [Security risks of trusted schemas](https://ajv.js.org/security.html#security-risks-of-trusted-schemas)
- [`allErrors` option](https://ajv.js.org/options.html#allerrors)

To report all validation errors (only recommended in development), option `allErrors` can be set in express-openapi-validator request and response validation options. For example:
```ts
app.use(
  OpenApiValidator.middleware({
    apiSpec: 'path/to/openapi.json',
    validateRequests: {
      allErrors: true,
    },
    validateResponses: {
      allErrors: true,
    },
  })
);
```

---

AJV security recommendations advise that `allErrors` should not be set to `true` in production (more details in #954). Update `createAjv()` so that it does not set `allErrors` by default and add support for letting users define `allErrors` in request and response validation options.

Added tests to ensure that the number of errors reported (when multiple are expected) is correct based on how `allErrors` is set (or unset).

The `allErrors` configuration for `OpenAPISchemaValidator` is not changed by this commit since that validation is for trusted content.

Fixes #954