### PR TITLE
Use lenient resolver return type

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -68,7 +68,7 @@ export type OperationHandlerOptions = {
     handlersPath: string,
     route: RouteMetadata,
     apiDoc: OpenAPIV3.Document,
-  ) => RequestHandler | Promise<RequestHandler>;
+  ) => unknown;
 };
 
 export type Format = {


### PR DESCRIPTION
In #921, a stronger type was applied to `OperationHandlerOptions['resolver']` so that end users would have an idea of what the parameters are for their custom resolvers. It went too far in stipulating a return type. Set the return type to `unknown` and let users decide how much type safety they need in their resolver.

Fixes #952