### PR TITLE
fix: Dereference path parameters

### DIFF
--- a/test/operation.handler.spec.ts
+++ b/test/operation.handler.spec.ts
@@ -120,4 +120,12 @@ describe('custom operation handler', () => {
       });
   });
 
+  it('should coerce path parameters', async () => {
+    return request(app)
+      .get(`${basePath}/users/123/info`)
+      .expect(200)
+      .then((r) => {
+        expect(r.text).to.be.equal('{"id":123}');
+      });
+  });
 });

--- a/test/resources/eov-operations.modulepath.yaml
+++ b/test/resources/eov-operations.modulepath.yaml
@@ -185,8 +185,35 @@ paths:
                 properties:
                   success:
                     type: boolean
+  /users/{userID}/info:
+    get:
+      description: Get info about a User
+      summary: Get info about a User
+      operationId: user.info
+      security: []
+      parameters: 
+        - $ref: '#/components/parameters/userID'
+      responses:
+        '200':
+          description: Returns info about a User.
+          content:
+            'application/json':
+              schema:
+                type: object
+                properties:
+                  id:
+                    $ref: '#/components/schemas/UserID'
 
 components:
+  parameters:
+    userID:
+      name: userID
+      in: path
+      required: true
+      schema: 
+        $ref: '#/components/schemas/UserID'
+        # type: number
+
   schemas:
     Pet:
       required:
@@ -209,6 +236,9 @@ components:
       enum:
         - dog
         - cat
+
+    UserID:
+      type: number
 
     Error:
       required:

--- a/test/resources/routes/user.js
+++ b/test/resources/routes/user.js
@@ -1,0 +1,3 @@
+module.exports = {
+  info: (req, res) => res.status(200).send({ id: req.params.userID })
+};


### PR DESCRIPTION
### 🐞 The Bug
The OpenAPI spec loader has a `discoverRoutes` method which explores an OpenAPI document and gathers information about the paths and parameters used.
The list of discovered path parameters is used to install parameter-specific middleware in `src/openapi.validator.ts#installPathParams`
Path parameters declared with `$ref` were not detected in the `discoverRoutes` implementation, leading to the un-coerced values being used.

### The Fix 🔧 
By dereferencing each path parameter when building this list, we should see the same behavior for referenced path parameters and for inline path parameters.

Closes https://github.com/cdimascio/express-openapi-validator/issues/803