### PR TITLE
fix: bump patch version to ensure latest dependencies loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-openapi-validator",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "express-openapi-validator",
-      "version": "5.3.5",
+      "version": "5.3.6",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-openapi-validator",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "Automatically validate API requests and responses with OpenAPI 3 and Express.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Would you be so kind to accept a patch update to allow the newly updated dependencies (`path-to-regexp v6.3.0`) to be loaded by the consumers of the `express-openapi-validator` module. Thanks