### PR TITLE
Support ESM import of handler module in default resolver

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -77,9 +77,9 @@ export type ValidateSecurityOpts = {
 };
 
 export type OperationHandlerOptions = {
-  basePath: string;
+  basePath: string | URL;
   resolver: (
-    handlersPath: string,
+    handlersPath: string | URL,
     route: RouteMetadata,
     apiDoc: OpenAPIV3.Document,
   ) => unknown;
@@ -169,7 +169,7 @@ export interface OpenApiValidatorOpts {
   $refParser?: {
     mode: 'bundle' | 'dereference';
   };
-  operationHandlers?: false | string | OperationHandlerOptions;
+  operationHandlers?: false | string | URL | OperationHandlerOptions;
   validateFormats?: boolean | 'fast' | 'full';
 }
 

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -232,14 +232,21 @@ class AuthValidator {
       const authHeader =
         req.headers['authorization'] &&
         req.headers['authorization'].toLowerCase();
-
-      if (!authHeader) {
+        const authCookie = req.cookies[scheme.name] || req.signedCookies?.[scheme.name]; 
+      if (!authHeader && !authCookie) {
         throw Error(`Authorization header required`);
       }
 
       const type = scheme.scheme && scheme.scheme.toLowerCase();
-      if (type === 'bearer' && !authHeader.includes('bearer')) {
-        throw Error(`Authorization header with scheme 'Bearer' required`);
+      if (type === 'bearer') {
+        if (authHeader && !authHeader.includes('bearer')) {
+          throw Error(`Authorization header with scheme 'Bearer' required`);
+        }
+        if (!authHeader && authCookie === undefined) {
+          throw Error(
+            `Bearer token required in authorization header or cookie`,
+          );
+        }
       }
 
       if (type === 'basic' && !authHeader.includes('basic')) {

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -56,7 +56,7 @@ export class OpenApiValidator {
     if (options.formats == null) options.formats = {};
     if (options.useRequestUrl == null) options.useRequestUrl = false;
 
-    if (typeof options.operationHandlers === 'string') {
+    if (typeof options.operationHandlers === 'string' || options.operationHandlers instanceof URL) {
       /**
        * Internally, we want to convert this to a value typed OperationHandlerOptions.
        * In this way, we can treat the value as such when we go to install (rather than


### PR DESCRIPTION
Make the default request handler resolver work in ESM projects by allowing a URL value for options.operationHandlers. If a URL is passed, then a dynamic import will be used to load handler modules. If a string is passed, then require() will be used.

Existing projects should not be adversely affected by this change. The assignment of a URL value to options.operationHandlers would be the indicator that a user wants to opt-in to this new import handling.

Fixes https://github.com/cdimascio/express-openapi-validator/issues/660
Fixes https://github.com/cdimascio/express-openapi-validator/issues/838

Notice
Because this project uses moduleResolution:node in tsconfig.json, it's not possible to write async import(...) directly in code. It has to be obscured so that the compiler does not replace it with require(). Hence, there is a very obvious HACK! in this PR that obscures import() via Function('x', 'return import(x)') (it's very similar to eval('import(...)')).

This hack will probably sink this PR, but I figured I'd post it at least as a proof of concept. Ideally, the module resolution for tsconfig would be updated to Node16, but that brings its own issues since resolveJsonModule:true would no longer work. Fix one issue, introduce another...

```bash
import {fileURLToPath, pathToFileURL} from 'node:url';
import path from 'node:path';

const __dirname = path.dirname(fileURLToPath(import.meta.url));
const handlersPath = path.join(__dirname, '../path/to/my-routes');

const eov = OpenApiValidator.middleware({
  operationHandlers: pathToFileURL(handlersPath),
  // <rest of configuration>
});
app.use(eov);
````
When defining x-eov-operation-handler in schemas, include the file extension on the module name. For example:

```bash
{
  "get": {
    "summary": "Get thing",
    "x-eov-operation-id": "getThing",
    "x-eov-operation-handler": "things.js", // <-- include file extension
    "responses": {
````