### PR TITLE
Support for ignoring validation based on specific method and path combinations

### DIFF
--- a/src/framework/openapi.context.ts
+++ b/src/framework/openapi.context.ts
@@ -32,17 +32,19 @@ export class OpenApiContext {
     this.serial = spec.serial;
   }
 
-  public isManagedRoute(path: string): boolean {
+  public isManagedRoute(path: string, method: string): boolean {
     for (const bp of this.basePaths) {
-      if (path.startsWith(bp) && !this.shouldIgnoreRoute(path)) {
+      if (path.startsWith(bp) && !this.shouldIgnoreRoute(path, method)) {
         return true;
       }
     }
     return false;
   }
 
-  public shouldIgnoreRoute(path: string) {
-    return typeof this.ignorePaths === 'function' ? this.ignorePaths(path) : this.ignorePaths?.test(path);
+  public shouldIgnoreRoute(path: string, method: string): boolean {
+    return typeof this.ignorePaths === 'function'
+      ? this.ignorePaths(path, method)
+      : this.ignorePaths?.test(path);
   }
 
   public routePair(route: string): RoutePair {

--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -22,7 +22,8 @@ export function applyOpenApiMetadata(
     const path = req.path.startsWith(req.baseUrl)
       ? req.path
       : `${req.baseUrl}/${req.path}`;
-    if (openApiContext.shouldIgnoreRoute(path)) {
+    const { method } = req;
+    if (openApiContext.shouldIgnoreRoute(path, method)) {
       return next();
     }
     const matched = lookupRoute(req, openApiContext.useRequestUrl);
@@ -56,7 +57,7 @@ export function applyOpenApiMetadata(
         (<any>req.openapi)._responseSchema = (<any>matched)._responseSchema;
       }
     } else if (
-      openApiContext.isManagedRoute(path) &&
+      openApiContext.isManagedRoute(path, method) &&
       !openApiContext.ignoreUndocumented
     ) {
       throw new NotFound({
@@ -71,7 +72,9 @@ export function applyOpenApiMetadata(
     req: OpenApiRequest,
     useRequestUrl: boolean,
   ): OpenApiRequestMetadata {
-    const path = useRequestUrl ? req.url.split('?')[0] : req.originalUrl.split('?')[0];
+    const path = useRequestUrl
+      ? req.url.split('?')[0]
+      : req.originalUrl.split('?')[0];
     const method = req.method;
     const routeEntries = Object.entries(openApiContext.expressRouteMap);
     for (const [expressRoute, methods] of routeEntries) {

--- a/test/ignore.paths.spec.ts
+++ b/test/ignore.paths.spec.ts
@@ -112,7 +112,11 @@ describe('ignorePaths as Function', () => {
     const apiSpec = path.join('test', 'resources', 'ignore.paths.yaml');
 
     app = await createApp(
-      { apiSpec, ignorePaths: (path) => path.endsWith('/hippies') },
+      {
+        apiSpec,
+        ignorePaths: (path, method) =>
+          path.endsWith('/hippies') && ['GET', 'POST'].includes(method),
+      },
       3005,
       app => {
         app.all('/v1/hippies', (req, res) => {
@@ -121,6 +125,7 @@ describe('ignorePaths as Function', () => {
             { id: 2, name: 'fred' },
           ]);
         });
+
         app.get('/v1/hippies/1', (req, res) => {
           res.json({ id: 1, name: 'farah' });
         });
@@ -155,6 +160,17 @@ describe('ignorePaths as Function', () => {
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200));
+
+  it('should not ignore path and return 405', async () =>
+    request(app)
+      .put(`${basePath}/hippies`)
+      .query({
+        test: 'one',
+        limit: 2,
+      })
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(405));
 
   it('should not ignore path and return 404', async () =>
     request(app)


### PR DESCRIPTION
Hi everyone,
I had a situation where I needed to ignore validation for certain combinations of `method` and `path` in my API, but currently, the `ignorePaths` function only accepts `path` as an argument. To address this, I’ve implemented support for passing `method` as a second argument to `ignorePaths`.

Example:
```js
{
   ignorePaths: (path, method) => path.endsWith('/demo') && method === 'POST'
}
```


Please take a look and let me know if you find this approach useful or have suggestions for improvement.

Thanks!