### PR TITLE
fix: fix authHeader without `cookie-parser` middleware

### DIFF
--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -232,8 +232,9 @@ class AuthValidator {
       const authHeader =
         req.headers['authorization'] &&
         req.headers['authorization'].toLowerCase();
+      // req.cookies will be `undefined` without `cookie-parser` middleware
       const authCookie =
-        req.cookies[scheme.name] || req.signedCookies?.[scheme.name];
+        req.cookies?.[scheme.name] || req.signedCookies?.[scheme.name];
   
       const type = scheme.scheme && scheme.scheme.toLowerCase();
       if (type === 'bearer') {


### PR DESCRIPTION
[express-openapi-validator v5.8.3][1] and 00d070b (fix: add cookie support for HTTP bearer authentication (#949), 2024-10-27) breaks HTTP bearer authentication when the `cookie-parser` middleware is not present (and therefore `req.cookies` is not present).

[1]: https://github.com/cdimascio/express-openapi-validator/releases/tag/v5.3.8
Fixes: 00d070b0f24396de0f32057f58e1c04b5f023199

### Error message

Without this fix, you'll get errors like:

```
Cannot read properties of undefined (reading 'undefined')
      at HttpError.create (/app/node_modules/.pnpm/express-openapi-validator@5.3.8_express@5.0.1/node_modules/express-openapi-validator/dist/framework/types.js:42:24)
      at /app/node_modules/.pnpm/express-openapi-validator@5.3.8_express@5.0.1/node_modules/express-openapi-validator/dist/middlewares/openapi.security.js:57:37
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
