### PR TITLE
re-enable keywords now properly supported

### DIFF
--- a/src/framework/ajv/index.ts
+++ b/src/framework/ajv/index.ts
@@ -61,9 +61,6 @@ function createAjv(
   for (let [formatName, formatDefinition] of Object.entries(options.formats)) {
     ajv.addFormat(formatName, formatDefinition);
   }
-  ajv.removeKeyword('propertyNames');
-  ajv.removeKeyword('contains');
-  ajv.removeKeyword('const');
 
   if (options.serDesMap) {
     // Alias for `type` that can execute AFTER x-eov-res-serdes

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -194,7 +194,7 @@ export interface NormalizedOpenApiValidatorOpts extends OpenApiValidatorOpts {
 
 export namespace OpenAPIV3 {
   export interface DocumentV3 {
-    openapi: string;
+    openapi: `3.0.${string}`;
     info: InfoObject;
     servers?: ServerObject[];
     paths: PathsObject;
@@ -208,7 +208,8 @@ export namespace OpenAPIV3 {
     pathItems?: { [path: string]: PathItemObject | ReferenceObject }
   }
 
-  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths' | 'info' | 'components'> {
+  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths' | 'info' | 'components'| "openapi" > {
+    openapi: `3.1.${string}`;
     paths?: DocumentV3['paths'];
     info: InfoObjectV3_1;
     components: ComponentsV3_1;

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -343,8 +343,8 @@ class Security {
     apiDocs: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
     schema: OperationObject,
   ): string[] {
-    const hasPathSecurity = schema.security?.length > 0 ?? false;
-    const hasRootSecurity = apiDocs.security?.length > 0 ?? false;
+    const hasPathSecurity = schema.security ? schema.security.length > 0 : false;
+    const hasRootSecurity = apiDocs.security ? apiDocs.security.length > 0 : false;
 
     let usedSecuritySchema: SecurityRequirementObject[] = [];
     if (hasPathSecurity) {


### PR DESCRIPTION
With https://github.com/cdimascio/express-openapi-validator/pull/882 merged, some keywords that where previously not relevant are should now be checked by ajv.