### PR TITLE
test(express-5): change routes in tests to new path route syntax

### DIFF
--- a/test/1022.spec.ts
+++ b/test/1022.spec.ts
@@ -125,10 +125,10 @@ describe(packageJson.name, () => {
             .get(`/api/test/:id`, (req, res) =>
               res.status(200).json({ id: 'id-test', label: 'label' }),
             )
-            .post(`/api/test/:id:clone`, (req, res) =>
+            .post(`/api/test/:id\\:clone`, (req, res) =>
               res.status(200).json({ ...req.body, id: 'id-test' }),
             )
-            .get('/api/some/:wildcard(*)', (req, res) => {
+            .get('/api/some/:wildcard(*wildcardSuffix)', (req, res) => {
               const wildcard = req.params.wildcard;
               console.log(`Wildcard: ${wildcard}`);
               res.status(200).send(`Matched wildcard: ${wildcard}`);

--- a/test/699.spec.ts
+++ b/test/699.spec.ts
@@ -53,7 +53,7 @@ describe('699', () => {
       },
       3005,
       (app) => {
-        app.get([`${app.basePath}/users/:id?`], (req, res) => {
+        app.get([`${app.basePath}/users/{:id}`], (req, res) => {
           if (typeof req.params.id !== 'object') {
             throw new Error("Should be deserialized to ObjectId object");
           }
@@ -181,7 +181,7 @@ describe('699 serialize response components only', () => {
       },
       3005,
       (app) => {
-        app.get([`${app.basePath}/users/:id?`], (req, res) => {
+        app.get([`${app.basePath}/users/{:id}`], (req, res) => {
           if (typeof req.params.id !== 'string') {
             throw new Error("Should be not be deserialized to ObjectId object");
           }

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -33,7 +33,7 @@ describe('a multipart request', () => {
                 metadata: req.body.metadata,
               });
             })
-            .post(`/sample_*`, (req, res) => res.json(req.body)),
+            .post(`/sample_*suffix`, (req, res) => res.json(req.body)),
         ),
     );
   });

--- a/test/path.params.spec.ts
+++ b/test/path.params.spec.ts
@@ -18,7 +18,7 @@ describe('path params', () => {
       3005,
       (app) => {
         app.get(
-          [`${app.basePath}/users/:id?`, `${app.basePath}/users_alt/:id?`],
+          [`${app.basePath}/users/{:id}`, `${app.basePath}/users_alt/{:id}`],
           (req, res) => {
             res.json({
               id: req.params.id,
@@ -30,7 +30,7 @@ describe('path params', () => {
             id: req.params.name,
           });
         });
-        app.get(`${app.basePath}/multi_users/:ids?`, (req, res) => {
+        app.get(`${app.basePath}/multi_users/{:ids}`, (req, res) => {
           res.json({
             ids: req.params.ids,
           });

--- a/test/serdes.spec.ts
+++ b/test/serdes.spec.ts
@@ -62,7 +62,7 @@ describe('serdes', () => {
       },
       3005,
       (app) => {
-        app.get([`${app.basePath}/users/:id?`], (req, res) => {
+        app.get([`${app.basePath}/users/{:id}`], (req, res) => {
           if (typeof req.params.id !== 'object') {
             throw new Error("Should be deserialized to ObjectId object");
           }
@@ -237,7 +237,7 @@ describe('serdes serialize response components only', () => {
       },
       3005,
       (app) => {
-        app.get([`${app.basePath}/users/:id?`], (req, res) => {
+        app.get([`${app.basePath}/users/{:id}`], (req, res) => {
           if (typeof req.params.id !== 'string') {
             throw new Error("Should be not be deserialized to ObjectId object");
           }
@@ -431,7 +431,7 @@ describe('serdes with array type string-list', () => {
       },
       3005,
       (app) => {
-        app.get([`${app.basePath}/users/:id?`], (req, res) => {
+        app.get([`${app.basePath}/users/{:id}`], (req, res) => {
           if (typeof req.params.id !== 'object') {
             throw new Error("Should be deserialized to ObjectId object");
           }


### PR DESCRIPTION
As mentioned in https://github.com/cdimascio/express-openapi-validator/issues/969, there are several failing tests when testing this lib against express 5. One of the reasons some tests are failing is due to the fact that express 5 changed its routing syntax, which made some tests fail in the "beforeAll" hook. This MR fixes some of them

There are still some tests that use wildcard syntax that break, but I haven't found a way to get around them just yet. I'll continue to investigate it, but it can be merged in another PR