### PR TITLE
Remove more examples from schemas

### DIFF
--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -463,7 +463,10 @@ export class SchemaPreprocessor {
     schema: OpenAPIV3.SchemaObject,
     opts,
   ) {
-    if (schema.type !== 'object') return;
+    const isComposition = ['oneOf', 'anyOf', 'allOf', 'not'].some(
+      (key) => key in schema && schema[key] !== undefined,
+    )
+    if (schema.type !== 'object' && !isComposition) return;
     if (schema?.example) {
       delete schema.example
     }


### PR DESCRIPTION
[1] did some work to resolve a false positive schema validation issue[2]. It's about examples with the "id" property.

As reported in [3] there may be examples with such property for schemas where type is not object.

This patch hopefully fixes all remaining instances of the problem.

[1] 0ad49ec78e0a ("remove examples from schema (#890)")
[2] https://github.com/cdimascio/express-openapi-validator/issues/773
[3] https://github.com/cdimascio/express-openapi-validator/pull/890#issuecomment-1914299643