### PR TITLE
feat: Re-design of the Preprocessor to Reach and Strip all Examples in the Schema

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -7,7 +7,7 @@ import AjvDraft4 from 'ajv-draft-04';
 import Ajv2020 from 'ajv/dist/2020';
 export { OpenAPIFrameworkArgs };
 
-export type AjvInstance = AjvDraft4 | Ajv2020 
+export type AjvInstance = AjvDraft4 | Ajv2020;
 
 export type BodySchema =
   | OpenAPIV3.ReferenceObject
@@ -48,7 +48,7 @@ export interface Options extends ajv.Options {
   ajvFormats?: FormatsPluginOptions;
 }
 
-export interface RequestValidatorOptions extends Options, ValidateRequestOpts { }
+export interface RequestValidatorOptions extends Options, ValidateRequestOpts {}
 
 export type ValidateRequestOpts = {
   /**
@@ -125,32 +125,42 @@ export class SerDesSingleton implements SerDes {
       serialize: param.serialize,
     };
   }
-};
-
-export type SerDesMap = {
-  [format: string]: SerDes
-};
-
-type Primitive = undefined | null | boolean | string | number | Function
-
-type Immutable<T> =
-  T extends Primitive ? T :
-    T extends Array<infer U> ? ReadonlyArray<U> :
-      T extends Map<infer K, infer V> ? ReadonlyMap<K, V> : Readonly<T>
-
-type DeepImmutable<T> =
-  T extends Primitive ? T :
-    T extends Array<infer U> ? DeepImmutableArray<U> :
-      T extends Map<infer K, infer V> ? DeepImmutableMap<K, V> : DeepImmutableObject<T>
-
-interface DeepImmutableArray<T> extends ReadonlyArray<DeepImmutable<T>> {}
-interface DeepImmutableMap<K, V> extends ReadonlyMap<DeepImmutable<K>, DeepImmutable<V>> {}
-type DeepImmutableObject<T> = {
-  readonly [K in keyof T]: DeepImmutable<T[K]>
 }
 
+export type SerDesMap = {
+  [format: string]: SerDes;
+};
+
+type Primitive = undefined | null | boolean | string | number | Function;
+
+type Immutable<T> = T extends Primitive
+  ? T
+  : T extends Array<infer U>
+  ? ReadonlyArray<U>
+  : T extends Map<infer K, infer V>
+  ? ReadonlyMap<K, V>
+  : Readonly<T>;
+
+type DeepImmutable<T> = T extends Primitive
+  ? T
+  : T extends Array<infer U>
+  ? DeepImmutableArray<U>
+  : T extends Map<infer K, infer V>
+  ? DeepImmutableMap<K, V>
+  : DeepImmutableObject<T>;
+
+interface DeepImmutableArray<T> extends ReadonlyArray<DeepImmutable<T>> {}
+interface DeepImmutableMap<K, V>
+  extends ReadonlyMap<DeepImmutable<K>, DeepImmutable<V>> {}
+type DeepImmutableObject<T> = {
+  readonly [K in keyof T]: DeepImmutable<T[K]>;
+};
+
 export interface OpenApiValidatorOpts {
-  apiSpec: DeepImmutable<OpenAPIV3.DocumentV3> | DeepImmutable<OpenAPIV3.DocumentV3_1> | string;
+  apiSpec:
+    | DeepImmutable<OpenAPIV3.DocumentV3>
+    | DeepImmutable<OpenAPIV3.DocumentV3_1>
+    | string;
   validateApiSpec?: boolean;
   validateResponses?: boolean | ValidateResponseOpts;
   validateRequests?: boolean | ValidateRequestOpts;
@@ -204,18 +214,19 @@ export namespace OpenAPIV3 {
     externalDocs?: ExternalDocumentationObject;
   }
 
-  interface ComponentsV3_1 extends ComponentsObject {
-    pathItems?: { [path: string]: PathItemObject | ReferenceObject }
+  export interface ComponentsV3_1 extends ComponentsObject {
+    pathItems?: { [path: string]: PathItemObject | ReferenceObject };
   }
 
-  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths' | 'info' | 'components'| "openapi" > {
+  export interface DocumentV3_1
+    extends Omit<DocumentV3, 'paths' | 'info' | 'components' | 'openapi'> {
     openapi: `3.1.${string}`;
     paths?: DocumentV3['paths'];
     info: InfoObjectV3_1;
     components: ComponentsV3_1;
     webhooks: {
-      [name: string]: PathItemObject | ReferenceObject
-    }
+      [name: string]: PathItemObject | ReferenceObject;
+    };
   }
 
   export interface InfoObject {
@@ -299,7 +310,7 @@ export namespace OpenAPIV3 {
     in: string;
   }
 
-  export interface HeaderObject extends ParameterBaseObject { }
+  export interface HeaderObject extends ParameterBaseObject {}
 
   interface ParameterBaseObject {
     description?: string;
@@ -323,14 +334,18 @@ export namespace OpenAPIV3 {
     | 'integer';
   export type ArraySchemaObjectType = 'array';
 
-  export type SchemaObject = ArraySchemaObject | NonArraySchemaObject | CompositionSchemaObject;
+  export type SchemaObject =
+    | ArraySchemaObject
+    | NonArraySchemaObject
+    | CompositionSchemaObject;
 
-  export interface ArraySchemaObject extends BaseSchemaObject<ArraySchemaObjectType> {
+  export interface ArraySchemaObject
+    extends BaseSchemaObject<ArraySchemaObjectType> {
     items: ReferenceObject | SchemaObject;
   }
 
-  export interface NonArraySchemaObject extends BaseSchemaObject<NonArraySchemaObjectType> {
-  }
+  export interface NonArraySchemaObject
+    extends BaseSchemaObject<NonArraySchemaObjectType> {}
 
   export interface CompositionSchemaObject extends BaseSchemaObject<undefined> {
     // JSON schema allowed properties, adjusted for OpenAPI

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -673,16 +673,18 @@ export class SchemaPreprocessor<
   ): VisitorNode<any>[] {
     const children = [];
 
-    children.push(...VisitorNode.fromParentDict(parent, 'pathItem', 'paths'));
-
     if (isDocumentV3_1(parent.object)) {
       children.push(
         VisitorNode.fromParent(parent, 'componentsV3_1', 'components'),
       );
-      children.push(VisitorNode.fromParentDict(parent, 'pathItem', 'webhooks'));
+      children.push(
+        ...VisitorNode.fromParentDict(parent, 'pathItem', 'webhooks'),
+      );
     } else {
       children.push(VisitorNode.fromParent(parent, 'components'));
     }
+
+    children.push(...VisitorNode.fromParentDict(parent, 'pathItem', 'paths'));
 
     return children;
   }

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -520,10 +520,6 @@ export class SchemaPreprocessor<
             this.ajv.compile(newSchema);
         }
       }
-
-      //reset data
-      //parentState.properties = {};
-      //delete parentState.required;
     }
   }
 

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -230,7 +230,15 @@ export class SchemaPreprocessor<
 
           // Resolve reference object in parent, then process again with resolved schema
           // As every object (aka schema) is 'pass-by-reference', this will update the actual apiDoc.
-          parent.object[node.path[-1]] = resolvedObject;
+          const lastPathComponent = node.path[node.path.length - 1];
+          if (isInteger(lastPathComponent)) {
+            const arrayName = node.path[node.path.length - 2];
+            const index = parseInt(lastPathComponent);
+            parent.object[arrayName][index] = resolvedObject;
+          } else {
+            parent.object[lastPathComponent] = resolvedObject;
+          }
+
           node.object = resolvedObject;
 
           return traverse(parent, node as VisitorNode<NodeType>, state);
@@ -967,4 +975,8 @@ function findKeys(
 
 function getKeyFromRef(ref: string) {
   return ref.split('/components/schemas/')[1];
+}
+
+function isInteger(str: string): boolean {
+  return /^\d+$/.test(str);
 }

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -234,6 +234,8 @@ export class SchemaPreprocessor<
           return;
         }
 
+        if (seenObjects.has(node.object)) return;
+
         if (isReferenceNode(node) && isReferenceObject(node.object)) {
           node.originalRef = node.object.$ref;
 
@@ -261,8 +263,6 @@ export class SchemaPreprocessor<
 
           return traverse(parent, node as VisitorNode<NodeType>, state);
         }
-
-        if (seenObjects.has(node.object)) return;
 
         seenObjects.add(node.object);
 

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -217,7 +217,7 @@ export class SchemaPreprocessor<
       state: VisitorState,
     ) => {
       try {
-        if (node.object === undefined || seenObjects.has(node.object)) {
+        if (node.object === undefined) {
           return;
         }
 
@@ -243,6 +243,8 @@ export class SchemaPreprocessor<
 
           return traverse(parent, node as VisitorNode<NodeType>, state);
         }
+
+        if (seenObjects.has(node.object)) return;
 
         seenObjects.add(node.object);
 

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -243,6 +243,17 @@ export class SchemaPreprocessor<
             node.object,
           );
 
+          if (seenObjects.has(resolvedObject)) {
+            if (hasNodeType(node, 'schema')) {
+              this.processDiscriminator(
+                hasNodeType(parent, 'schema') ? parent : undefined,
+                node,
+              );
+            }
+
+            return;
+          }
+
           // Resolve reference object in parent, then process again with resolved schema
           // As every object (aka schema) is 'pass-by-reference', this will update the actual apiDoc.
           if (node.pathFromParent && node.pathFromParent.length > 0) {

--- a/test/ignore.examples.spec.ts
+++ b/test/ignore.examples.spec.ts
@@ -1,0 +1,143 @@
+import * as request from 'supertest';
+import { createApp } from './common/app';
+import * as packageJson from '../package.json';
+
+describe(packageJson.name, () => {
+  let app = null;
+
+  before(async () => {
+    // set up express app
+    app = await createApp(
+      {
+        apiSpec: apiSpec(),
+        validateRequests: true,
+        validateResponses: true,
+      },
+      3001,
+      (app) => {
+        app.post('/ping', (req: any, res: any) => {
+          res.json({
+            id: req.body.id,
+            message: 'Pong!',
+          });
+        });
+      },
+      false,
+    );
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('should not throw an error when more than one example uses the same the value for a property "id"', async () =>
+    request(app)
+      .post('/ping')
+      .send({ id: 'id', message: 'Ping!' })
+      .expect(200));
+});
+
+function apiSpec(): any {
+  return {
+    openapi: '3.0.0',
+    info: {
+      version: 'v1',
+      title: 'Validation Error',
+      description:
+        'A test spec that triggers an validation error on identical id fields in examples.',
+    },
+    paths: {
+      '/ping': {
+        post: {
+          description: 'ping then pong!',
+          operationId: 'ping',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Data',
+                },
+                examples: {
+                  request1: {
+                    summary: 'Request 1',
+                    value: {
+                      id: 'Some_ID_A',
+                      message: 'Ping!',
+                    },
+                  },
+                  request2: {
+                    summary: 'Request 2',
+                    value: {
+                      id: 'Some_ID_A',
+                      message: 'Ping!',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Data',
+                  },
+                  examples: {
+                    response1: {
+                      summary: 'Response 1',
+                      value: {
+                        id: 'Some_ID_B',
+                        message: 'Pong!',
+                      },
+                    },
+                    response2: {
+                      summary: 'Response 2',
+                      value: {
+                        id: 'Some_ID_B',
+                        message: 'Pong!',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Data: {
+          required: ['id', 'message'],
+          properties: {
+            id: {
+              type: 'string',
+            },
+            message: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      examples: {
+        example1: {
+          summary: 'Example 1',
+          value: {
+            id: 'Some_ID_C',
+            message: 'Example!',
+          },
+        },
+        response2: {
+          summary: 'Example 2',
+          value: {
+            id: 'Some_ID_C',
+            message: 'Example!',
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
This MR is a spin-off of #1040, and aims to fix #931. It introduces the following changes:

- Add a test to verify #931 has been fixed.
- Expose an additional type from the OpenAPIV3 namespace (and fixes `prettier` in the types file).
- Redesign the preprocessor to scan the entire API schema for examples, using the same pattern as the original implementation.

The changes are quite extensive. The new preprocessor serves as a drop-in replacement, but changes how the schema is traversed. Most importantly, it traverses much more of the schema than the old design, which is required to reach all examples. In turn, it only requires a single pass to perform pre-processing and stripping all examples, in contrast to the simpler solution provided in #1040.

If you have any questions about it, let me know!

Closes #931.
Replaces #1040.