### PR TITLE
fix: use `Array.isArray` instead of `instanceof Array`  for checking …

### DIFF
--- a/src/middlewares/parsers/req.parameter.mutator.ts
+++ b/src/middlewares/parsers/req.parameter.mutator.ts
@@ -328,7 +328,7 @@ export class RequestParameterMutator {
      * forcing convert to array if scheme describes param as array + explode
      */
     const field = REQUEST_FIELDS[$in];
-    if (req[field]?.[name] && !(req[field][name] instanceof Array)) {
+    if (req[field]?.[name] && !Array.isArray(req[field][name])) {
       const value = [req[field][name]];
       req[field][name] = value;
     }


### PR DESCRIPTION
…whether parameters are already an array

Using `instanceof Array` can be problematic because it fails for Arrays constructed in another realm. `Array.isArray` is more robust.

We were running into issues where this actually failed in integration tests. Unfortunately, it’s difficult to reproduce, which is why I have not added a test case for this. But this change reliably fixes the problem for us and does not appear to have any downsides. [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#description) also recommends `Array.isArray` as a more robust alternative to `instanceof Array`.