### PR TITLE
Optimise Ajv cache usage

### DIFF
--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -295,7 +295,7 @@ export class ResponseValidator {
         const schema = contentTypeSchemas[contentType];
         schema.paths = this.spec.paths; // add paths for resolution with multi-file
         schema.components = this.spec.components; // add components for resolution w/ multi-file
-        const validator = useAjvCache(this.ajvBody, schema, `${ajvCacheKey}-${contentType}`)
+        const validator = useAjvCache(this.ajvBody, <object>schema, `${ajvCacheKey}-${code}-${contentType}`)
         validators[code] = {
           ...validators[code],
           [contentType]: validator,

--- a/src/middlewares/util.ts
+++ b/src/middlewares/util.ts
@@ -1,6 +1,6 @@
 import type { ErrorObject } from 'ajv-draft-04';
 import { Request } from 'express';
-import { ValidationError } from '../framework/types';
+import { AjvInstance, ValidationError } from '../framework/types';
 
 export class ContentType {
   public readonly mediaType: string = null;
@@ -171,3 +171,20 @@ export const zipObject = (keys, values) =>
     return acc
   }, {})
 
+/**
+ * Tries to fetch a schema from ajv instance by the provided key and adds and
+ * compiles the schema under provided key. We provide a key to avoid ajv library
+ * using the whole schema as a cache key, leading to a lot of unnecessary memory
+ * usage - this is not recommended by the library either:
+ * https://ajv.js.org/guide/managing-schemas.html#cache-key-schema-vs-key-vs-id
+ *
+ * @param ajvCacheKey - Key which will be used for ajv cache
+ */
+export function useAjvCache(ajv: AjvInstance, schema: object, ajvCacheKey: string) {
+  let validator = ajv.getSchema(ajvCacheKey);
+  if (!validator) {
+    ajv.addSchema(schema, ajvCacheKey);
+    validator = ajv.getSchema(ajvCacheKey);
+  }
+  return validator
+}

--- a/src/middlewares/util.ts
+++ b/src/middlewares/util.ts
@@ -172,8 +172,8 @@ export const zipObject = (keys, values) =>
   }, {})
 
 /**
- * Tries to fetch a schema from ajv instance by the provided key and adds and
- * compiles the schema under provided key. We provide a key to avoid ajv library
+ * Tries to fetch a schema from ajv instance by the provided key otherwise adds (and
+ * compiles) the schema under provided key. We provide a key to avoid ajv library
  * using the whole schema as a cache key, leading to a lot of unnecessary memory
  * usage - this is not recommended by the library either:
  * https://ajv.js.org/guide/managing-schemas.html#cache-key-schema-vs-key-vs-id


### PR DESCRIPTION
Introducing a key which can be used to for caching in by Ajv library.
Currently the whole schema is used as a cache key in each `ajv` instance[^1],
for very large schemas this leads to a lot of unnecessary memory usage since
a whole string representation of the schema is stored with each `compile()`.

The `ajv` cache is never used, since there's already a cache implementation
in the code base, but by passing a much shorter key to `ajv` we optimise
memory usage.

[^1]: https://ajv.js.org/guide/managing-schemas.html#cache-key-schema-vs-key-vs-id