### PR TITLE
fix(#1071): Fix query param validation for literal bracket notation in param names

### DIFF
--- a/src/middlewares/parsers/req.parameter.mutator.ts
+++ b/src/middlewares/parsers/req.parameter.mutator.ts
@@ -453,10 +453,6 @@ export class RequestParameterMutator {
     return result;
   }
 
-  // Cache for literal bracket parameters per endpoint
-  private readonly literalBracketParamsCache = new Map<string, Set<string>>();
-
-
   /**
    * Handles query parameters with bracket notation.
    * @param query The query parameters object to process

--- a/src/middlewares/parsers/req.parameter.mutator.ts
+++ b/src/middlewares/parsers/req.parameter.mutator.ts
@@ -495,7 +495,7 @@ class BracketNotationHandler {
         if (!literalBracketParams.has(key)) {
           // Use qs.parse to handle it as a nested object
           const normalizedKey = key.split('[')[0];
-          const parsed = parse(`${key}=${this.query[key]}`);
+          const parsed = parse(`${key}=${query[key]}`);
 
           // Use the parsed value for the normalized key
           if (parsed[normalizedKey] !== undefined) {

--- a/src/middlewares/parsers/req.parameter.mutator.ts
+++ b/src/middlewares/parsers/req.parameter.mutator.ts
@@ -100,7 +100,6 @@ export class RequestParameterMutator {
         this.handleContent(req, name, parameter);
       } else if (parameter.in === 'query' && this.isObjectOrXOf(schema)) {
         // handle bracket notation and mutates query param
-        
 
         if (style === 'form' && explode) {
           this.parseJsonAndMutateRequest(req, parameter.in, name);
@@ -428,28 +427,30 @@ export class RequestParameterMutator {
     }, new Map<string, string[]>());
   }
 
-  private csvToKeyValuePairs(csvString: string): Record<string, string> | undefined {
+  private csvToKeyValuePairs(
+    csvString: string,
+  ): Record<string, string> | undefined {
     const hasBrace = csvString.split('{').length > 1;
     const items = csvString.split(',');
-    
+
     if (hasBrace) {
       // if it has a brace, we assume its JSON and skip creating k v pairs
       // TODO improve json check, but ensure its cheap
       return;
     }
-  
+
     if (items.length % 2 !== 0) {
-      // if the number of elements is not event, 
+      // if the number of elements is not event,
       // then we do not have k v pairs, so return undefined
       return;
     }
 
     const result = {};
-    
+
     for (let i = 0; i < items.length - 1; i += 2) {
       result[items[i]] = items[i + 1];
     }
-    
+
     return result;
   }
 
@@ -534,9 +535,9 @@ class BracketNotationHandler {
 
     // Use all available identifiers to ensure uniqueness
     const path = schema.path ?? '';
-    const method = (schema.method ?? '');
+    const method = schema.method ?? '';
     const operationId = schema.operationId ?? '';
-    
+
     // Combine all parts with a consistent separator
     return `${path}|${method}|${operationId}`;
   }

--- a/src/middlewares/parsers/req.parameter.mutator.ts
+++ b/src/middlewares/parsers/req.parameter.mutator.ts
@@ -490,7 +490,14 @@ export class RequestParameterMutator {
           
           // Use the parsed value for the normalized key
           if (parsed[normalizedKey] !== undefined) {
-            result[normalizedKey] = parsed[normalizedKey];
+            // If we already have a value for this key, merge the objects
+            if (result[normalizedKey] && typeof result[normalizedKey] === 'object' && 
+                typeof parsed[normalizedKey] === 'object' && 
+                !Array.isArray(parsed[normalizedKey])) {
+              result[normalizedKey] = { ...result[normalizedKey], ...parsed[normalizedKey] };
+            } else {
+              result[normalizedKey] = parsed[normalizedKey];
+            }
           }
           
           // Remove the original bracketed key

--- a/test/query.bracket.notation.spec.ts
+++ b/test/query.bracket.notation.spec.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { RequestParameterMutator } from '../src/middlewares/parsers/req.parameter.mutator';
+import Ajv from 'ajv';
+import { OpenAPIV3 } from '../src/framework/types';
+
+type DocumentV3 = OpenAPIV3.DocumentV3;
+
+describe('RequestParameterMutator - handleBracketNotationQueryFields', () => {
+  const ajv = new Ajv();
+  const mockApiDoc: DocumentV3 = {
+    openapi: '3.0.0',
+    info: { title: 'Test', version: '1.0.0' },
+    paths: {}
+  };
+
+  const createMockRequest = (query: any) => ({
+    query,
+    _openapi: {
+      schema: {
+        parameters: [
+          // This simulates the parameters defined in the OpenAPI spec
+          { name: 'filter[name]', in: 'query', schema: { type: 'string' } },
+          { name: 'user', in: 'query', schema: { type: 'object' } }
+        ]
+      }
+    }
+  });
+
+  const testValidationSchema = {
+    body: {},
+    query: {
+      type: 'object',
+      properties: {
+        'filter[name]': { type: 'string' },
+        'user': { type: 'object' },
+        'user[name]': { type: 'string' },
+        'user[age]': { type: 'string' },
+        'simple': { type: 'string' },
+        'another': { type: 'string' }
+      },
+      additionalProperties: true
+    },
+    headers: {},
+    params: {},
+    cookies: {}
+  };
+
+  it('should preserve literal bracket notation when defined in the spec', () => {
+    // Arrange
+    const req = createMockRequest({
+      'filter[name]': 'test',
+      _openapi: { schema: { parameters: [{ name: 'filter[name]', in: 'query' }] } }
+    });
+    const mutator = new RequestParameterMutator(ajv, mockApiDoc, '/test', testValidationSchema);
+
+    // Act
+    const result = mutator['handleBracketNotationQueryFields'](req.query);
+
+    // Assert
+    expect(result).to.have.property('filter[name]', 'test');
+    expect(result).to.not.have.property('filter');
+  });
+
+  it('should parse bracket notation as nested object when not defined in spec', () => {
+    // Arrange
+    const req = createMockRequest({
+      'user[name]': 'John',
+      'user[age]': '30',
+      _openapi: { schema: { parameters: [{ name: 'user', in: 'query', schema: { type: 'object' } }] } }
+    });
+    const mutator = new RequestParameterMutator(ajv, mockApiDoc, '/test', testValidationSchema);
+
+    // Act
+    const result = mutator['handleBracketNotationQueryFields'](req.query);
+
+    // Assert
+    expect(result).to.have.property('user');
+    expect(result.user).to.deep.equal({ name: 'John', age: '30' });
+    expect(result).to.not.have.property('user[name]');
+    expect(result).to.not.have.property('user[age]');
+  });
+
+  it('should handle mixed literal and nested bracket notation', () => {
+    // Arrange
+    const req = createMockRequest({
+      'filter[name]': 'test',
+      'user[age]': '30',
+      _openapi: { 
+        schema: { 
+          parameters: [
+            { name: 'filter[name]', in: 'query', schema: { type: 'string' } },
+            { name: 'user', in: 'query', schema: { type: 'object' } }
+          ] 
+        } 
+      }
+    });
+    const mutator = new RequestParameterMutator(ajv, mockApiDoc, '/test', testValidationSchema);
+
+    // Act
+    const result = mutator['handleBracketNotationQueryFields'](req.query);
+
+    // Assert
+    expect(result).to.have.property('filter[name]', 'test');
+    expect(result).to.have.property('user');
+    expect(result.user).to.deep.equal({ age: '30' });
+    expect(result).to.not.have.property('filter');
+    expect(result).to.not.have.property('user[age]');
+  });
+
+  it('should not modify parameters without brackets', () => {
+    // Arrange
+    const req = createMockRequest({
+      simple: 'value',
+      another: 'test',
+      _openapi: { schema: { parameters: [] } }
+    });
+    const mutator = new RequestParameterMutator(ajv, mockApiDoc, '/test', testValidationSchema);
+    testValidationSchema
+    // Act
+    const result = mutator['handleBracketNotationQueryFields'](req.query);
+
+    // Assert
+    expect(result).to.deep.equal({
+      simple: 'value',
+      another: 'test',
+      _openapi: { schema: { parameters: [] } }
+    });
+  });
+});


### PR DESCRIPTION
fixes https://github.com/cdimascio/express-openapi-validator/issues/1071
