### PR TITLE
add onError to validateRequestOptions

### DIFF
--- a/src/framework/ajv/options.ts
+++ b/src/framework/ajv/options.ts
@@ -30,14 +30,19 @@ export class AjvOptions {
   }
 
   get request(): RequestValidatorOptions {
-    const { allErrors, allowUnknownQueryParameters, coerceTypes, removeAdditional } = <
-      ValidateRequestOpts
-    >this.options.validateRequests;
+    const {
+      allErrors,
+      allowUnknownQueryParameters,
+      coerceTypes,
+      removeAdditional,
+      onError,
+    } = <ValidateRequestOpts>this.options.validateRequests;
     return {
       ...this.baseOptions(),
       allErrors,
       allowUnknownQueryParameters,
       coerceTypes,
+      onError,
       removeAdditional,
     };
   }
@@ -47,13 +52,8 @@ export class AjvOptions {
   }
 
   private baseOptions(): Options {
-    const {
-      coerceTypes,
-      formats,
-      validateFormats,
-      serDes,
-      ajvFormats,
-    } = this.options;
+    const { coerceTypes, formats, validateFormats, serDes, ajvFormats } =
+      this.options;
     const serDesMap = {};
     for (const serDesObject of serDes) {
       if (!serDesMap[serDesObject.format]) {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -61,6 +61,7 @@ export type ValidateRequestOpts = {
   allowUnknownQueryParameters?: boolean;
   coerceTypes?: boolean | 'array';
   removeAdditional?: boolean | 'all' | 'failing';
+  onError?: (err: InternalServerError, json: any, req: Request) => void;
 };
 
 export type ValidateResponseOpts = {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -7,7 +7,7 @@ import AjvDraft4 from 'ajv-draft-04';
 import Ajv2020 from 'ajv/dist/2020';
 export { OpenAPIFrameworkArgs };
 
-export type AjvInstance = AjvDraft4 | Ajv2020;
+export type AjvInstance = AjvDraft4 | Ajv2020 
 
 export type BodySchema =
   | OpenAPIV3.ReferenceObject
@@ -48,7 +48,7 @@ export interface Options extends ajv.Options {
   ajvFormats?: FormatsPluginOptions;
 }
 
-export interface RequestValidatorOptions extends Options, ValidateRequestOpts {}
+export interface RequestValidatorOptions extends Options, ValidateRequestOpts { }
 
 export type ValidateRequestOpts = {
   /**
@@ -126,42 +126,32 @@ export class SerDesSingleton implements SerDes {
       serialize: param.serialize,
     };
   }
-}
+};
 
 export type SerDesMap = {
-  [format: string]: SerDes;
+  [format: string]: SerDes
 };
 
-type Primitive = undefined | null | boolean | string | number | Function;
+type Primitive = undefined | null | boolean | string | number | Function
 
-type Immutable<T> = T extends Primitive
-  ? T
-  : T extends Array<infer U>
-    ? ReadonlyArray<U>
-    : T extends Map<infer K, infer V>
-      ? ReadonlyMap<K, V>
-      : Readonly<T>;
+type Immutable<T> =
+  T extends Primitive ? T :
+    T extends Array<infer U> ? ReadonlyArray<U> :
+      T extends Map<infer K, infer V> ? ReadonlyMap<K, V> : Readonly<T>
 
-type DeepImmutable<T> = T extends Primitive
-  ? T
-  : T extends Array<infer U>
-    ? DeepImmutableArray<U>
-    : T extends Map<infer K, infer V>
-      ? DeepImmutableMap<K, V>
-      : DeepImmutableObject<T>;
+type DeepImmutable<T> =
+  T extends Primitive ? T :
+    T extends Array<infer U> ? DeepImmutableArray<U> :
+      T extends Map<infer K, infer V> ? DeepImmutableMap<K, V> : DeepImmutableObject<T>
 
 interface DeepImmutableArray<T> extends ReadonlyArray<DeepImmutable<T>> {}
-interface DeepImmutableMap<K, V>
-  extends ReadonlyMap<DeepImmutable<K>, DeepImmutable<V>> {}
+interface DeepImmutableMap<K, V> extends ReadonlyMap<DeepImmutable<K>, DeepImmutable<V>> {}
 type DeepImmutableObject<T> = {
-  readonly [K in keyof T]: DeepImmutable<T[K]>;
-};
+  readonly [K in keyof T]: DeepImmutable<T[K]>
+}
 
 export interface OpenApiValidatorOpts {
-  apiSpec:
-    | DeepImmutable<OpenAPIV3.DocumentV3>
-    | DeepImmutable<OpenAPIV3.DocumentV3_1>
-    | string;
+  apiSpec: DeepImmutable<OpenAPIV3.DocumentV3> | DeepImmutable<OpenAPIV3.DocumentV3_1> | string;
   validateApiSpec?: boolean;
   validateResponses?: boolean | ValidateResponseOpts;
   validateRequests?: boolean | ValidateRequestOpts;
@@ -216,18 +206,17 @@ export namespace OpenAPIV3 {
   }
 
   interface ComponentsV3_1 extends ComponentsObject {
-    pathItems?: { [path: string]: PathItemObject | ReferenceObject };
+    pathItems?: { [path: string]: PathItemObject | ReferenceObject }
   }
 
-  export interface DocumentV3_1
-    extends Omit<DocumentV3, 'paths' | 'info' | 'components' | 'openapi'> {
+  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths' | 'info' | 'components'| "openapi" > {
     openapi: `3.1.${string}`;
     paths?: DocumentV3['paths'];
     info: InfoObjectV3_1;
     components: ComponentsV3_1;
     webhooks: {
-      [name: string]: PathItemObject | ReferenceObject;
-    };
+      [name: string]: PathItemObject | ReferenceObject
+    }
   }
 
   export interface InfoObject {
@@ -311,7 +300,7 @@ export namespace OpenAPIV3 {
     in: string;
   }
 
-  export interface HeaderObject extends ParameterBaseObject {}
+  export interface HeaderObject extends ParameterBaseObject { }
 
   interface ParameterBaseObject {
     description?: string;
@@ -335,18 +324,14 @@ export namespace OpenAPIV3 {
     | 'integer';
   export type ArraySchemaObjectType = 'array';
 
-  export type SchemaObject =
-    | ArraySchemaObject
-    | NonArraySchemaObject
-    | CompositionSchemaObject;
+  export type SchemaObject = ArraySchemaObject | NonArraySchemaObject | CompositionSchemaObject;
 
-  export interface ArraySchemaObject
-    extends BaseSchemaObject<ArraySchemaObjectType> {
+  export interface ArraySchemaObject extends BaseSchemaObject<ArraySchemaObjectType> {
     items: ReferenceObject | SchemaObject;
   }
 
-  export interface NonArraySchemaObject
-    extends BaseSchemaObject<NonArraySchemaObjectType> {}
+  export interface NonArraySchemaObject extends BaseSchemaObject<NonArraySchemaObjectType> {
+  }
 
   export interface CompositionSchemaObject extends BaseSchemaObject<undefined> {
     // JSON schema allowed properties, adjusted for OpenAPI

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -7,7 +7,7 @@ import AjvDraft4 from 'ajv-draft-04';
 import Ajv2020 from 'ajv/dist/2020';
 export { OpenAPIFrameworkArgs };
 
-export type AjvInstance = AjvDraft4 | Ajv2020 
+export type AjvInstance = AjvDraft4 | Ajv2020;
 
 export type BodySchema =
   | OpenAPIV3.ReferenceObject
@@ -48,7 +48,7 @@ export interface Options extends ajv.Options {
   ajvFormats?: FormatsPluginOptions;
 }
 
-export interface RequestValidatorOptions extends Options, ValidateRequestOpts { }
+export interface RequestValidatorOptions extends Options, ValidateRequestOpts {}
 
 export type ValidateRequestOpts = {
   /**
@@ -61,7 +61,7 @@ export type ValidateRequestOpts = {
   allowUnknownQueryParameters?: boolean;
   coerceTypes?: boolean | 'array';
   removeAdditional?: boolean | 'all' | 'failing';
-  onError?: (err: InternalServerError, json: any, req: Request) => void;
+  onError?: (err: InternalServerError, req: Request) => void;
 };
 
 export type ValidateResponseOpts = {
@@ -126,32 +126,42 @@ export class SerDesSingleton implements SerDes {
       serialize: param.serialize,
     };
   }
-};
-
-export type SerDesMap = {
-  [format: string]: SerDes
-};
-
-type Primitive = undefined | null | boolean | string | number | Function
-
-type Immutable<T> =
-  T extends Primitive ? T :
-    T extends Array<infer U> ? ReadonlyArray<U> :
-      T extends Map<infer K, infer V> ? ReadonlyMap<K, V> : Readonly<T>
-
-type DeepImmutable<T> =
-  T extends Primitive ? T :
-    T extends Array<infer U> ? DeepImmutableArray<U> :
-      T extends Map<infer K, infer V> ? DeepImmutableMap<K, V> : DeepImmutableObject<T>
-
-interface DeepImmutableArray<T> extends ReadonlyArray<DeepImmutable<T>> {}
-interface DeepImmutableMap<K, V> extends ReadonlyMap<DeepImmutable<K>, DeepImmutable<V>> {}
-type DeepImmutableObject<T> = {
-  readonly [K in keyof T]: DeepImmutable<T[K]>
 }
 
+export type SerDesMap = {
+  [format: string]: SerDes;
+};
+
+type Primitive = undefined | null | boolean | string | number | Function;
+
+type Immutable<T> = T extends Primitive
+  ? T
+  : T extends Array<infer U>
+    ? ReadonlyArray<U>
+    : T extends Map<infer K, infer V>
+      ? ReadonlyMap<K, V>
+      : Readonly<T>;
+
+type DeepImmutable<T> = T extends Primitive
+  ? T
+  : T extends Array<infer U>
+    ? DeepImmutableArray<U>
+    : T extends Map<infer K, infer V>
+      ? DeepImmutableMap<K, V>
+      : DeepImmutableObject<T>;
+
+interface DeepImmutableArray<T> extends ReadonlyArray<DeepImmutable<T>> {}
+interface DeepImmutableMap<K, V>
+  extends ReadonlyMap<DeepImmutable<K>, DeepImmutable<V>> {}
+type DeepImmutableObject<T> = {
+  readonly [K in keyof T]: DeepImmutable<T[K]>;
+};
+
 export interface OpenApiValidatorOpts {
-  apiSpec: DeepImmutable<OpenAPIV3.DocumentV3> | DeepImmutable<OpenAPIV3.DocumentV3_1> | string;
+  apiSpec:
+    | DeepImmutable<OpenAPIV3.DocumentV3>
+    | DeepImmutable<OpenAPIV3.DocumentV3_1>
+    | string;
   validateApiSpec?: boolean;
   validateResponses?: boolean | ValidateResponseOpts;
   validateRequests?: boolean | ValidateRequestOpts;
@@ -206,17 +216,18 @@ export namespace OpenAPIV3 {
   }
 
   interface ComponentsV3_1 extends ComponentsObject {
-    pathItems?: { [path: string]: PathItemObject | ReferenceObject }
+    pathItems?: { [path: string]: PathItemObject | ReferenceObject };
   }
 
-  export interface DocumentV3_1 extends Omit<DocumentV3, 'paths' | 'info' | 'components'| "openapi" > {
+  export interface DocumentV3_1
+    extends Omit<DocumentV3, 'paths' | 'info' | 'components' | 'openapi'> {
     openapi: `3.1.${string}`;
     paths?: DocumentV3['paths'];
     info: InfoObjectV3_1;
     components: ComponentsV3_1;
     webhooks: {
-      [name: string]: PathItemObject | ReferenceObject
-    }
+      [name: string]: PathItemObject | ReferenceObject;
+    };
   }
 
   export interface InfoObject {
@@ -300,7 +311,7 @@ export namespace OpenAPIV3 {
     in: string;
   }
 
-  export interface HeaderObject extends ParameterBaseObject { }
+  export interface HeaderObject extends ParameterBaseObject {}
 
   interface ParameterBaseObject {
     description?: string;
@@ -324,14 +335,18 @@ export namespace OpenAPIV3 {
     | 'integer';
   export type ArraySchemaObjectType = 'array';
 
-  export type SchemaObject = ArraySchemaObject | NonArraySchemaObject | CompositionSchemaObject;
+  export type SchemaObject =
+    | ArraySchemaObject
+    | NonArraySchemaObject
+    | CompositionSchemaObject;
 
-  export interface ArraySchemaObject extends BaseSchemaObject<ArraySchemaObjectType> {
+  export interface ArraySchemaObject
+    extends BaseSchemaObject<ArraySchemaObjectType> {
     items: ReferenceObject | SchemaObject;
   }
 
-  export interface NonArraySchemaObject extends BaseSchemaObject<NonArraySchemaObjectType> {
-  }
+  export interface NonArraySchemaObject
+    extends BaseSchemaObject<NonArraySchemaObjectType> {}
 
   export interface CompositionSchemaObject extends BaseSchemaObject<undefined> {
     // JSON schema allowed properties, adjusted for OpenAPI

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -180,13 +180,11 @@ export class RequestValidator {
         } catch (error) {
           if (this.requestOpts.onError) {
             this.requestOpts.onError(error, req);
-            console.log(`XXX invoked errorhandler`);
           } else {
             throw error;
           }
         }
       }
-      console.log(`XXX done`);
 
       const schemaBody = <any>validator?.schemaBody;
       if (contentType.mediaType === 'multipart/form-data') {

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -46,6 +46,7 @@ export class RequestValidator {
     delete this.apiDoc.components?.examples;
     this.requestOpts.allowUnknownQueryParameters =
       options.allowUnknownQueryParameters;
+    this.requestOpts.onError = options.onError;
 
     this.ajv = createRequestAjv(
       apiDoc,
@@ -157,11 +158,19 @@ export class RequestValidator {
       mutator.modifyRequest(req);
 
       if (!allowUnknownQueryParameters) {
+        try {
         this.processQueryParam(
           req.query,
           schemaProperties.query,
           securityQueryParam,
         );
+	} catch (error) {
+          if (this.requestOpts.onError) {
+	    this.requestOpts.onError(error, body, req);
+	  } else {
+	    throw error;
+	  }
+	}
       }
 
       const schemaBody = <any>validator?.schemaBody;
@@ -218,7 +227,11 @@ export class RequestValidator {
           message: message,
         });
         error.errors = err.errors;
-        throw error;
+	if (this.requestOpts.onError) {
+	  this.requestOpts.onError(error, body, req);
+	} else {
+          throw error;
+	}
       }
     };
   }

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -179,7 +179,7 @@ export class RequestValidator {
           );
         } catch (error) {
           if (this.requestOpts.onError) {
-            this.requestOpts.onError(error, body, req);
+            this.requestOpts.onError(error, req);
             console.log(`XXX invoked errorhandler`);
           } else {
             throw error;
@@ -243,7 +243,7 @@ export class RequestValidator {
         });
         error.errors = err.errors;
         if (this.requestOpts.onError) {
-          this.requestOpts.onError(error, body, req);
+          this.requestOpts.onError(error, req);
           next();
         } else {
           throw error;

--- a/test/request.validation.on.error.spec.ts
+++ b/test/request.validation.on.error.spec.ts
@@ -1,0 +1,104 @@
+import * as path from 'path';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { createApp } from './common/app';
+import * as packageJson from '../package.json';
+import { AppWithServer } from './common/app.common';
+
+const apiSpecPath = path.join('test', 'resources', 'request.validation.yaml');
+
+describe(packageJson.name, () => {
+  let app: AppWithServer;
+
+  let onErrorArgs: any[] | null;
+  before(async () => {
+    // set up express app
+    app = await createApp(
+      {
+        apiSpec: apiSpecPath,
+        validateResponses: false,
+        validateRequests: {
+          onError: function (_err, body, req) {
+            console.log(`XXX in onError`);
+            onErrorArgs = Array.from(arguments);
+            if (req.query['mode'] === 'bad_type_throw') {
+              throw new Error('error in onError handler');
+            }
+            console.log(`XXX not throwing`);
+          },
+        },
+      },
+      3005,
+      (app) => {
+        app.get(`${app.basePath}/users`, (_req, res) => {
+          const json = ['user1', 'user2', 'user3'];
+          res.json(json);
+        });
+        app.get(`${app.basePath}/pets`, (req, res) => {
+          let json = {};
+          if (req.query.mode === 'bad_type') {
+            json = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
+          } else if (req.query.mode === 'bad_type_throw') {
+            json = [{ id: 'bad_id_throw', name: 'name', tag: 'tag' }];
+          }
+          res.json(json);
+        });
+        app.use((err, _req, res, _next) => {
+          res.status(err.status ?? 500).json({
+            message: err.message,
+            code: err.status ?? 500,
+          });
+        });
+      },
+      false,
+    );
+  });
+
+  afterEach(() => {
+    onErrorArgs = null;
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('custom error handler invoked if request query field has the wrong type', async () =>
+    request(app)
+      .get(`${app.basePath}/pets?limit=not_an_integer`)
+      .expect(200)
+      .then((r: any) => {
+        const data = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
+        expect(r.body).to.eql(data);
+        expect(onErrorArgs?.length).to.equal(3);
+        expect(onErrorArgs![0].message).to.equal(
+          '/response/0/id must be integer',
+        );
+        expect(onErrorArgs![1]).to.eql(data);
+        expect(onErrorArgs![2].query).to.eql({
+          mode: 'bad_type',
+        });
+      }));
+
+  it('custom error handler not invoked on valid response', async () =>
+    request(app)
+      .get(`${app.basePath}/pets?limit=3`)
+      .expect(200)
+      .then((r: any) => {
+        expect(r.body).is.an('array').with.length(3);
+        expect(onErrorArgs).to.equal(null);
+      }));
+
+  it('returns error if custom error handler throws', async () =>
+    request(app)
+      .get(`${app.basePath}/pets?mode=bad_type_throw`)
+      .expect(500)
+      .then((r: any) => {
+        const data = [{ id: 'bad_id_throw', name: 'name', tag: 'tag' }];
+        expect(r.body.message).to.equal('error in onError handler');
+        expect(onErrorArgs!.length).to.equal(3);
+        expect(onErrorArgs![0].message).to.equal(
+          '/response/0/id must be integer',
+        );
+        expect(onErrorArgs![1]).to.eql(data);
+      }));
+});

--- a/test/request.validation.on.error.spec.ts
+++ b/test/request.validation.on.error.spec.ts
@@ -30,16 +30,16 @@ describe(packageJson.name, () => {
       },
       3005,
       (app) => {
-        app.get(`${app.basePath}/users`, (_req, res) => {
-          const json = ['user1', 'user2', 'user3'];
-          res.json(json);
-        });
         app.get(`${app.basePath}/pets`, (req, res) => {
-          let json = {};
-          if (req.query.mode === 'bad_type') {
-            json = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
-          } else if (req.query.mode === 'bad_type_throw') {
-            json = [{ id: 'bad_id_throw', name: 'name', tag: 'tag' }];
+          let json = [
+            { id: '1', name: 'fido' },
+            { id: '2', name: 'rex' },
+            { id: '3', name: 'spot' },
+          ];
+          if (req.query.limit === 'not_an_integer') {
+            json = [{ id: 'bad_limit', name: 'not an int' }];
+          } else if (req.query.limit === 'bad_type_throw') {
+            json = [{ id: 'bad_limit_throw', name: 'name' }];
           }
           res.json(json);
         });
@@ -67,7 +67,7 @@ describe(packageJson.name, () => {
       .get(`${app.basePath}/pets?limit=not_an_integer`)
       .expect(200)
       .then((r: any) => {
-        const data = [{ id: 'bad_id', name: 'name', tag: 'tag' }];
+        const data = [{ id: 'bad_limit', name: 'not an int' }];
         expect(r.body).to.eql(data);
         expect(onErrorArgs?.length).to.equal(3);
         expect(onErrorArgs![0].message).to.equal(
@@ -93,7 +93,7 @@ describe(packageJson.name, () => {
       .get(`${app.basePath}/pets?mode=bad_type_throw`)
       .expect(500)
       .then((r: any) => {
-        const data = [{ id: 'bad_id_throw', name: 'name', tag: 'tag' }];
+        const data = [{ id: 'bad_limit_throw', name: 'name' }];
         expect(r.body.message).to.equal('error in onError handler');
         expect(onErrorArgs!.length).to.equal(3);
         expect(onErrorArgs![0].message).to.equal(

--- a/test/request.validation.on.error.spec.ts
+++ b/test/request.validation.on.error.spec.ts
@@ -18,9 +18,9 @@ describe(packageJson.name, () => {
         apiSpec: apiSpecPath,
         validateResponses: false,
         validateRequests: {
-          onError: function (_err, body, req) {
+          onError: function (_err, req) {
             console.log(`XXX in onError`);
-            onErrorArgs = Array.from(arguments);
+            onErrorArgs = [_err, req];
             if (req.query['limit'] === 'bad_type_throw') {
               throw new Error('error in onError handler');
             }
@@ -72,13 +72,12 @@ describe(packageJson.name, () => {
       .then((r: any) => {
         const data = [{ id: 'bad_limit', name: 'not an int' }];
         expect(r.body).to.eql(data);
-        expect(onErrorArgs?.length).to.equal(3);
+        expect(onErrorArgs?.length).to.equal(2);
         expect(onErrorArgs![0].message).to.equal(
           'request/query/limit must be integer',
         );
-        expect(onErrorArgs![1]).to.eql(data);
-        expect(onErrorArgs![2].query).to.eql({
-          mode: 'bad_type',
+        expect(onErrorArgs![1].query).to.eql({
+          limit: 'not_an_integer',
         });
       }));
 
@@ -98,10 +97,12 @@ describe(packageJson.name, () => {
       .then((r: any) => {
         const data = [{ id: 'bad_limit_throw', name: 'name' }];
         expect(r.body.message).to.equal('error in onError handler');
-        expect(onErrorArgs!.length).to.equal(3);
+        expect(onErrorArgs!.length).to.equal(2);
         expect(onErrorArgs![0].message).to.equal(
-          '/response/0/id must be integer',
+          'request/query/limit must be integer',
         );
-        expect(onErrorArgs![1]).to.eql(data);
+        expect(onErrorArgs![1].query).to.eql({
+          limit: 'bad_type_throw',
+        });
       }));
 });

--- a/test/request.validation.on.error.spec.ts
+++ b/test/request.validation.on.error.spec.ts
@@ -94,6 +94,19 @@ describe(packageJson.name, () => {
         });
       }));
 
+  it('custom error handler not invoked if has unknown query parameter, but is allowed', async () => {
+    app.server.close();
+    app = await buildApp({ allowUnknownQueryParameters: true });
+
+    request(app)
+      .get(`${app.basePath}/pets?limit=3&unknown_param=123`)
+      .expect(200)
+      .then((r: any) => {
+        expect(r.body).is.an('array').with.length(3);
+        expect(onErrorArgs).to.equal(null);
+      });
+  });
+
   it('custom error handler invoked if request query field has the wrong type', async () =>
     request(app)
       .get(`${app.basePath}/pets?limit=not_an_integer`)

--- a/test/request.validation.on.error.spec.ts
+++ b/test/request.validation.on.error.spec.ts
@@ -21,7 +21,7 @@ describe(packageJson.name, () => {
           onError: function (_err, body, req) {
             console.log(`XXX in onError`);
             onErrorArgs = Array.from(arguments);
-            if (req.query['mode'] === 'bad_type_throw') {
+            if (req.query['limit'] === 'bad_type_throw') {
               throw new Error('error in onError handler');
             }
             console.log(`XXX not throwing`);
@@ -31,6 +31,8 @@ describe(packageJson.name, () => {
       3005,
       (app) => {
         app.get(`${app.basePath}/pets`, (req, res) => {
+          debugger;
+          console.log(`XXX in route`);
           let json = [
             { id: '1', name: 'fido' },
             { id: '2', name: 'rex' },
@@ -41,6 +43,7 @@ describe(packageJson.name, () => {
           } else if (req.query.limit === 'bad_type_throw') {
             json = [{ id: 'bad_limit_throw', name: 'name' }];
           }
+          console.log(`XXX returning json`, json);
           res.json(json);
         });
         app.use((err, _req, res, _next) => {
@@ -71,7 +74,7 @@ describe(packageJson.name, () => {
         expect(r.body).to.eql(data);
         expect(onErrorArgs?.length).to.equal(3);
         expect(onErrorArgs![0].message).to.equal(
-          '/response/0/id must be integer',
+          'request/query/limit must be integer',
         );
         expect(onErrorArgs![1]).to.eql(data);
         expect(onErrorArgs![2].query).to.eql({
@@ -90,7 +93,7 @@ describe(packageJson.name, () => {
 
   it('returns error if custom error handler throws', async () =>
     request(app)
-      .get(`${app.basePath}/pets?mode=bad_type_throw`)
+      .get(`${app.basePath}/pets?limit=bad_type_throw`)
       .expect(500)
       .then((r: any) => {
         const data = [{ id: 'bad_limit_throw', name: 'name' }];

--- a/test/request.validation.on.error.spec.ts
+++ b/test/request.validation.on.error.spec.ts
@@ -21,12 +21,10 @@ async function buildApp({
       validateRequests: {
         allowUnknownQueryParameters,
         onError: function (_err, req) {
-          console.log(`XXX in onError`);
           onErrorArgs = [_err, req];
           if (req.query['limit'] === 'bad_type_throw') {
             throw new Error('error in onError handler');
           }
-          console.log(`XXX not throwing`);
         },
       },
     },
@@ -34,7 +32,6 @@ async function buildApp({
     (app) => {
       app.get(`${app.basePath}/pets`, (req, res) => {
         debugger;
-        console.log(`XXX in route`);
         let json = [
           { id: '1', name: 'fido' },
           { id: '2', name: 'rex' },
@@ -47,7 +44,6 @@ async function buildApp({
         } else if (req.query.limit === 'bad_type_throw') {
           json = [{ id: 'bad_limit_throw', name: 'name' }];
         }
-        console.log(`XXX returning json`, json);
         res.json(json);
       });
       app.use((err, _req, res, _next) => {

--- a/test/resources/request.validation.yaml
+++ b/test/resources/request.validation.yaml
@@ -232,8 +232,9 @@ components:
             - id
           properties:
             id:
-              type: integer
-              format: int64
+              type: string
+            name:
+              type: string
 
     Users:
       description: 'Generic list of values from database schema'

--- a/test/resources/request.validation.yaml
+++ b/test/resources/request.validation.yaml
@@ -110,10 +110,10 @@ paths:
       description: find pets
       operationId: findPets
       parameters:
-        - name: limit
+        - name: mode
           in: query
           schema:
-            type: integer
+            type: string
       responses:
         '200':
           description: pet response

--- a/test/resources/request.validation.yaml
+++ b/test/resources/request.validation.yaml
@@ -110,10 +110,10 @@ paths:
       description: find pets
       operationId: findPets
       parameters:
-        - name: mode
+        - name: limit
           in: query
           schema:
-            type: string
+            type: integer
       responses:
         '200':
           description: pet response

--- a/test/resources/response.validation.yaml
+++ b/test/resources/response.validation.yaml
@@ -110,10 +110,10 @@ paths:
       description: find pets
       operationId: findPets
       parameters:
-        - name: limit
+        - name: mode
           in: query
           schema:
-            type: integer
+            type: string
       responses:
         '200':
           description: pet response


### PR DESCRIPTION
I would like to be able to slowly and safely introduce this to an existing project. It's possible that we have some misbehaving clients, an I'd like to be able to identify cases where we aren't correctly describing types, without necessarily breaking the clients.

It seems like to do this, and be aware of bad requests, I want an `onError` option in `ValidateRequestOptions`, the same way it exists in `ValidateResponseOptions`.

This PR is an attempt to accomplish that. I cribbed pretty liberally from the same tests for response validation, and I'd believe of course that I'm missing something. I welcome comments!