### PR TITLE
Remove deprecated `lodash.get` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "content-type": "^1.0.5",
         "json-schema-traverse": "^1.0.0",
         "lodash.clonedeep": "^4.5.0",
-        "lodash.get": "^4.4.2",
         "media-typer": "^1.1.0",
         "multer": "^2.0.2",
         "ono": "^7.1.3",
@@ -4022,12 +4021,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead."
     },
     "node_modules/lodash.map": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "content-type": "^1.0.5",
     "json-schema-traverse": "^1.0.0",
     "lodash.clonedeep": "^4.5.0",
-    "lodash.get": "^4.4.2",
     "media-typer": "^1.1.0",
     "multer": "^2.0.2",
     "ono": "^7.1.3",

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -1,7 +1,6 @@
 import Ajv from 'ajv';
 import ajv = require('ajv');
 import * as cloneDeep from 'lodash.clonedeep';
-import * as _get from 'lodash.get';
 import { createRequestAjv } from '../../framework/ajv';
 import {
   OpenAPIV3,
@@ -63,6 +62,10 @@ function isNonArraySchemaObject(
   node: ArraySchemaObject | NonArraySchemaObject | ReferenceObject,
 ): node is NonArraySchemaObject {
   return !isArraySchemaObject(node) && !isReferenceObject(node);
+}
+
+function _get(object: Object, path: string[] | undefined): any {
+  return path?.reduce((o, p) => o?.[p], object);
 }
 
 class Root<T> extends Node<T, T> {
@@ -643,9 +646,9 @@ export class SchemaPreprocessor {
     }
     let res = (ref ? this.ajv.getSchema(ref)?.schema : schema) as T;
     if (ref && !res) {
-      const path = ref.split('/').join('.');
-      const p = path.substring(path.indexOf('.') + 1);
-      res = _get(this.apiDoc, p);
+      const path = ref.split('/');
+      path.shift();
+      res = _get(this.apiDoc, path);
     }
     if (ref) {
       this.resolvedSchemaCache.set(ref, res);


### PR DESCRIPTION
This PR removes [`lodash.get`](https://www.npmjs.com/package/lodash.get) package and replaces it with a simpler function.

Closes #1107