### PR TITLE
Fix: Return error from attempted security scheme instead of first defined scheme

### DIFF
--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -161,7 +161,7 @@ class SecuritySchemes {
               throw new InternalServerError({ message });
             }
             new AuthValidator(req, scheme, scopes).validate();
-            // If we reach here, validation passed and credentials were provided
+            // If we reach here, AuthValidator did not report validation errors for this scheme
             validatorPassed = true;
             // expected handler results are:
             // - throw exception,

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -88,9 +88,18 @@ export function security(
         next();
       } else {
         const errors = extractErrorsFromResults(results);
-        // Prioritize errors where authentication was actually attempted
-        const attemptedErrors = errors.filter(e => e.attempted);
-        const errorToThrow = attemptedErrors.length > 0 ? attemptedErrors[0] : errors[0];
+        // Prefer server/configuration errors (5xx) so misconfigurations surface
+        const serverErrors = errors.filter(
+          (e) => typeof e.status === 'number' && e.status >= 500 && e.status < 600,
+        );
+        let errorToThrow;
+        if (serverErrors.length > 0) {
+          errorToThrow = serverErrors[0];
+        } else {
+          // Otherwise, prioritize errors where authentication was actually attempted
+          const attemptedErrors = errors.filter((e) => e.attempted);
+          errorToThrow = attemptedErrors.length > 0 ? attemptedErrors[0] : errors[0];
+        }
         throw errorToThrow;
       }
     } catch (e) {

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -21,7 +21,7 @@ type SecuritySchemesMap = {
 interface SecurityHandlerResult {
   success: boolean;
   status?: number;
-  error?: string;
+  error?: any;
   attempted?: boolean; // true if AuthValidator.validate() passed for this scheme and the handler was called
 }
 

--- a/src/middlewares/openapi.security.ts
+++ b/src/middlewares/openapi.security.ts
@@ -22,7 +22,7 @@ interface SecurityHandlerResult {
   success: boolean;
   status?: number;
   error?: string;
-  attempted?: boolean; // true if credentials were provided and handler was called
+  attempted?: boolean; // true if AuthValidator.validate() passed for this scheme and the handler was called
 }
 
 function extractErrorsFromResults(results: (SecurityHandlerResult | SecurityHandlerResult[])[]) {

--- a/test/resources/security.yaml
+++ b/test/resources/security.yaml
@@ -19,6 +19,17 @@ paths:
           description: OK
         "401":
           description: unauthorized
+  
+  /bearer_or_apikey:
+    get:
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: unauthorized
 
   /no_security:
     get:


### PR DESCRIPTION
## Problem
When multiple security schemes are defined (e.g., `BearerAuth OR ApiKeyAuth`) and a user provides credentials for only one scheme, the error returned was always from the first defined security scheme rather than the one actually attempted.

### Example
Given this OpenAPI security configuration:
```yaml
security:
  - BearerAuth: []
  - ApiKeyAuth: []
```

#### Before this fix
User sends request with an invalid ApiKey but no Bearer token.
ApiKey validation runs and fails with "Invalid API key".
❌ Error returned: "Authorization header required" (from BearerAuth, which wasn't attempted).

#### After this fix
User sends request with an invalid ApiKey but no Bearer token.
ApiKey validation runs and fails with "Invalid API key"
✅ Error returned: "Invalid API key provided" (from ApiKeyAuth, which was actually attempted)

## Solution
Added an attempted flag to track which security schemes received credentials. The error selection logic now prioritizes errors from schemes where authentication was actually attempted over schemes where credentials were missing.

Closes #1118 