### PR TITLE
Add support for i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,44 @@ app.use(
 );
 ```
 
+### Internationalization (i18n)
+
+Validation error messages can be localized using [ajv-i18n](https://github.com/ajv-validator/ajv-i18n). Set `ajvLocale` to a supported locale key (e.g. `'de'`, `'ru'`, `'zh'`).
+
+**Static locale** — all errors use the same language:
+
+```javascript
+app.use(
+  OpenApiValidator.middleware({
+    apiSpec: './openapi.yaml',
+    ajvLocale: 'de', // German error messages
+  }),
+);
+```
+
+**Dynamic locale** — resolve the locale per-request via a function. This works with any request-scoped mechanism such as `AsyncLocalStorage`:
+
+```javascript
+import { AsyncLocalStorage } from 'async_hooks';
+
+const localeStorage = new AsyncLocalStorage();
+
+// Upstream middleware: store the locale for the current request
+app.use((req, res, next) => {
+  const lang = req.headers['accept-language']?.split(',')[0]?.trim() ?? 'en';
+  localeStorage.run(lang, next);
+});
+
+app.use(
+  OpenApiValidator.middleware({
+    apiSpec: './openapi.yaml',
+    ajvLocale: () => localeStorage.getStore(), // called fresh on every request
+  }),
+);
+```
+
+Supported locales include: `ar`, `ca`, `cs`, `de`, `en`, `es`, `fi`, `fr`, `hu`, `id`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `ru`, `sk`, `sv`, `th`, `tr`, `uk`, `vi`, `zh`, `zh-TW`.
+
 3. Register an error handler
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -70,44 +70,6 @@ app.use(
 );
 ```
 
-### Internationalization (i18n)
-
-Validation error messages can be localized using [ajv-i18n](https://github.com/ajv-validator/ajv-i18n). Set `ajvLocale` to a supported locale key (e.g. `'de'`, `'ru'`, `'zh'`).
-
-**Static locale** — all errors use the same language:
-
-```javascript
-app.use(
-  OpenApiValidator.middleware({
-    apiSpec: './openapi.yaml',
-    ajvLocale: 'de', // German error messages
-  }),
-);
-```
-
-**Dynamic locale** — resolve the locale per-request via a function. This works with any request-scoped mechanism such as `AsyncLocalStorage`:
-
-```javascript
-import { AsyncLocalStorage } from 'async_hooks';
-
-const localeStorage = new AsyncLocalStorage();
-
-// Upstream middleware: store the locale for the current request
-app.use((req, res, next) => {
-  const lang = req.headers['accept-language']?.split(',')[0]?.trim() ?? 'en';
-  localeStorage.run(lang, next);
-});
-
-app.use(
-  OpenApiValidator.middleware({
-    apiSpec: './openapi.yaml',
-    ajvLocale: () => localeStorage.getStore(), // called fresh on every request
-  }),
-);
-```
-
-Supported locales include: `ar`, `ca`, `cs`, `de`, `en`, `es`, `fi`, `fr`, `hu`, `id`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `ru`, `sk`, `sv`, `th`, `tr`, `uk`, `vi`, `zh`, `zh-TW`.
-
 3. Register an error handler
 
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "ajv-formats": "^3.0.1",
+        "ajv-i18n": "^4.2.0",
         "content-type": "^1.0.5",
         "json-schema-traverse": "^1.0.0",
         "lodash.clonedeep": "^4.5.0",
@@ -129,6 +130,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1008,6 +1010,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -1078,6 +1081,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
       "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1238,6 +1242,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1276,6 +1281,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1646,6 +1660,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2116,23 +2131,6 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/cosmiconfig-typescript-loader": {
       "version": "4.2.0",
@@ -6441,6 +6439,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6563,6 +6562,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
+    "ajv-i18n": "^4.2.0",
     "content-type": "^1.0.5",
     "json-schema-traverse": "^1.0.0",
     "lodash.clonedeep": "^4.5.0",

--- a/src/framework/ajv/index.ts
+++ b/src/framework/ajv/index.ts
@@ -31,7 +31,7 @@ function createAjv(
   options: Options = {},
   request = true,
 ): AjvInstance {
-  const { ajvFormats, ...ajvOptions } = options;
+  const { ajvFormats, ajvLocale, ...ajvOptions } = options;
 
   const ajv = factoryAjv(openApiSpec.openapi, {
     ...ajvOptions,

--- a/src/framework/ajv/options.ts
+++ b/src/framework/ajv/options.ts
@@ -2,6 +2,7 @@ import {
   NormalizedOpenApiValidatorOpts,
   Options,
   RequestValidatorOptions,
+  ResponseValidatorOptions,
   ValidateRequestOpts,
   ValidateResponseOpts,
 } from '../types';
@@ -16,7 +17,7 @@ export class AjvOptions {
     return this.baseOptions();
   }
 
-  get response(): Options {
+  get response(): ResponseValidatorOptions {
     const { allErrors, coerceTypes, removeAdditional } = <ValidateResponseOpts>(
       this.options.validateResponses
     );

--- a/src/framework/ajv/options.ts
+++ b/src/framework/ajv/options.ts
@@ -54,6 +54,7 @@ export class AjvOptions {
       validateFormats,
       serDes,
       ajvFormats,
+      ajvLocale,
     } = this.options;
     const serDesMap = {};
     for (const serDesObject of serDes) {
@@ -82,6 +83,7 @@ export class AjvOptions {
       formats,
       serDesMap,
       ajvFormats,
+      ajvLocale,
     };
 
     return options;

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -54,6 +54,8 @@ export interface Options extends ajv.Options {
   ajvLocale?: string | (() => string | undefined);
 }
 
+export interface ResponseValidatorOptions extends Options, ValidateResponseOpts { }
+
 export interface RequestValidatorOptions extends Options, ValidateRequestOpts { }
 
 export type ValidateRequestOpts = {

--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -46,6 +46,12 @@ export interface Options extends ajv.Options {
   // Specific options
   serDesMap?: SerDesMap;
   ajvFormats?: FormatsPluginOptions;
+  /**
+   * Locale for ajv-i18n (e.g. 'ru', 'de', 'zh'). Localizes AJV validation error messages.
+   * Can be a static string or a function that returns the locale per-request (e.g. reading
+   * from AsyncLocalStorage or a request-scoped context).
+   */
+  ajvLocale?: string | (() => string | undefined);
 }
 
 export interface RequestValidatorOptions extends Options, ValidateRequestOpts { }
@@ -169,6 +175,12 @@ export interface OpenApiValidatorOpts {
   serDes?: SerDes[];
   formats?: Format[] | Record<string, ajv.Format>;
   ajvFormats?: FormatsPluginOptions;
+  /**
+   * Locale for ajv-i18n (e.g. 'ru', 'de', 'zh'). Localizes AJV validation error messages.
+   * Can be a static string or a function that returns the locale per-request (e.g. reading
+   * from AsyncLocalStorage or a request-scoped context).
+   */
+  ajvLocale?: string | (() => string | undefined);
   fileUploader?: boolean | multer.Options;
   multerOpts?: multer.Options;
   $refParser?: {

--- a/src/middlewares/openapi.request.validator.ts
+++ b/src/middlewares/openapi.request.validator.ts
@@ -1,4 +1,5 @@
 import Ajv, { ValidateFunction } from 'ajv';
+import * as localize from 'ajv-i18n';
 import { NextFunction, RequestHandler, Response } from 'express';
 import { createRequestAjv } from '../framework/ajv';
 import {
@@ -35,6 +36,7 @@ export class RequestValidator {
   private ajv: Ajv;
   private ajvBody: Ajv;
   private requestOpts: ValidateRequestOpts = {};
+  private ajvLocale: string | (() => string | undefined) | undefined;
 
   constructor(
     apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
@@ -46,6 +48,7 @@ export class RequestValidator {
     delete this.apiDoc.components?.examples;
     this.requestOpts.allowUnknownQueryParameters =
       options.allowUnknownQueryParameters;
+    this.ajvLocale = options.ajvLocale;
 
     this.ajv = createRequestAjv(
       apiDoc,
@@ -206,11 +209,14 @@ export class RequestValidator {
       if (valid && validBody) {
         next();
       } else {
-        const errors = augmentAjvErrors(
-          []
-            .concat(validator.validatorGeneral.errors ?? [])
-            .concat(validatorBody.errors ?? []),
-        );
+        const rawErrors = []
+          .concat(validator.validatorGeneral.errors ?? [])
+          .concat(validatorBody.errors ?? []);
+        const locale = typeof this.ajvLocale === 'function' ? this.ajvLocale() : this.ajvLocale;
+        if (locale && localize[locale]) {
+          localize[locale](rawErrors);
+        }
+        const errors = augmentAjvErrors(rawErrors);
         const err = ajvErrorsToValidatorError(400, errors);
         const message = this.ajv.errorsText(errors, { dataVar: 'request' });
         const error: BadRequest = new BadRequest({

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -15,6 +15,7 @@ import {
   OpenApiRequestMetadata,
   InternalServerError,
   ValidateResponseOpts,
+  ResponseValidatorOptions,
 } from '../framework/types';
 import * as mediaTypeParser from 'media-typer';
 import * as contentTypeParser from 'content-type';
@@ -38,7 +39,7 @@ export class ResponseValidator {
 
   constructor(
     openApiSpec: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
-    options: Options = {},
+    options: ResponseValidatorOptions = {},
     eovOptions: ValidateResponseOpts = {},
     serial: number = -1,
   ) {
@@ -46,7 +47,7 @@ export class ResponseValidator {
     this.ajvBody = createResponseAjv(openApiSpec, options);
     this.eovOptions = eovOptions;
     this.serial = serial;
-    this.ajvLocale = (options as any).ajvLocale;
+    this.ajvLocale = options.ajvLocale;
 
     // This is a pseudo-middleware function. It doesn't get registered with
     // express via `use`

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express';
 import Ajv, { ValidateFunction, Options } from 'ajv';
+import * as localize from 'ajv-i18n';
 import mung from '../framework/modded.express.mung';
 import { createResponseAjv } from '../framework/ajv';
 import {
@@ -33,6 +34,7 @@ export class ResponseValidator {
   } = {};
   private eovOptions: ValidateResponseOpts;
   private serial: number;
+  private ajvLocale: string | (() => string | undefined) | undefined;
 
   constructor(
     openApiSpec: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
@@ -44,6 +46,7 @@ export class ResponseValidator {
     this.ajvBody = createResponseAjv(openApiSpec, options);
     this.eovOptions = eovOptions;
     this.serial = serial;
+    this.ajvLocale = (options as any).ajvLocale;
 
     // This is a pseudo-middleware function. It doesn't get registered with
     // express via `use`
@@ -194,7 +197,12 @@ export class ResponseValidator {
     });
 
     if (!valid) {
-      const errors = augmentAjvErrors(validator.errors);
+      const rawErrors = validator.errors;
+      const locale = typeof this.ajvLocale === 'function' ? this.ajvLocale() : this.ajvLocale;
+      if (locale && localize[locale]) {
+        localize[locale](rawErrors);
+      }
+      const errors = augmentAjvErrors(rawErrors);
       const message = this.ajvBody.errorsText(errors, {
         dataVar: '', // responses
       });

--- a/test/i18n.spec.ts
+++ b/test/i18n.spec.ts
@@ -1,0 +1,229 @@
+import * as path from 'path';
+import * as request from 'supertest';
+import { expect } from 'chai';
+import { createApp } from './common/app';
+import { AppWithServer } from './common/app.common';
+
+const apiSpec = path.join('test', 'resources', 'multiple-validations.yaml');
+
+// A handler that writes a too-long value back so the response validator fires.
+const defineRoutes = (app: AppWithServer) => {
+  app.post(`${app.basePath}/persons`, (req, res) => {
+    res.json({ success: true });
+  });
+  app.get(`${app.basePath}/persons`, (req, res) => {
+    // Deliberately echo the raw query value so the response schema
+    // (Person with bname maxLength:10 / format:starts-with-b) rejects it.
+    res.json({ bname: req.query.bname });
+  });
+};
+
+describe('i18n – ajvLocale', () => {
+  describe('static string locale', () => {
+    let app: AppWithServer;
+
+    before(async () => {
+      app = await createApp(
+        {
+          apiSpec,
+          formats: { 'starts-with-b': (v) => /^b/i.test(v) },
+          ajvLocale: 'de',
+          validateRequests: { allErrors: true },
+          validateResponses: { allErrors: true },
+        },
+        3008,
+        defineRoutes,
+        true,
+      );
+    });
+
+    after(() => app.server.close());
+
+    it('request errors should be in German when ajvLocale is "de"', async () => {
+      const res = await request(app)
+        .post(`${app.basePath}/persons`)
+        .set('content-type', 'application/json')
+        .send({ bname: 'Maximillian' }) // violates maxLength:10
+        .expect(400);
+
+      // German AJV messages contain German keywords – at minimum they must
+      // differ from the English defaults ("must NOT have more than").
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      // English default would be "must NOT have more than 10 characters" –
+      // German equivalent starts with "darf höchstens" or similar.
+      messages.forEach((msg) => {
+        expect(msg).to.not.match(/must NOT have more than/i);
+      });
+    });
+
+    it('response errors should be in German when ajvLocale is "de"', async () => {
+      const res = await request(app)
+        .get(`${app.basePath}/persons?bname=Maximillian`)
+        .expect(500);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      messages.forEach((msg) => {
+        expect(msg).to.not.match(/must NOT have more than/i);
+      });
+    });
+  });
+
+  describe('function locale', () => {
+    let app: AppWithServer;
+    let currentLocale = 'de';
+
+    before(async () => {
+      app = await createApp(
+        {
+          apiSpec,
+          formats: { 'starts-with-b': (v) => /^b/i.test(v) },
+          ajvLocale: () => currentLocale,
+          validateRequests: { allErrors: true },
+          validateResponses: { allErrors: true },
+        },
+        3009,
+        defineRoutes,
+        true,
+      );
+    });
+
+    after(() => app.server.close());
+
+    it('should use German messages when locale function returns "de"', async () => {
+      currentLocale = 'de';
+      const res = await request(app)
+        .post(`${app.basePath}/persons`)
+        .set('content-type', 'application/json')
+        .send({ bname: 'Maximillian' })
+        .expect(400);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      messages.forEach((msg) => {
+        expect(msg).to.not.match(/must NOT have more than/i);
+      });
+    });
+
+    it('should use Russian messages when locale function returns "ru"', async () => {
+      currentLocale = 'ru';
+      const res = await request(app)
+        .post(`${app.basePath}/persons`)
+        .set('content-type', 'application/json')
+        .send({ bname: 'Maximillian' })
+        .expect(400);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      messages.forEach((msg) => {
+        expect(msg).to.not.match(/must NOT have more than/i);
+      });
+    });
+  });
+
+  describe('no locale (default English)', () => {
+    let app: AppWithServer;
+
+    before(async () => {
+      app = await createApp(
+        {
+          apiSpec,
+          formats: { 'starts-with-b': (v) => /^b/i.test(v) },
+          validateRequests: { allErrors: true },
+        },
+        3010,
+        defineRoutes,
+        true,
+      );
+    });
+
+    after(() => app.server.close());
+
+    it('should return English messages when no ajvLocale is set', async () => {
+      const res = await request(app)
+        .post(`${app.basePath}/persons`)
+        .set('content-type', 'application/json')
+        .send({ bname: 'Maximillian' })
+        .expect(400);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      // At least one error should contain the English AJV message text.
+      const hasEnglish = messages.some((msg) =>
+        /must NOT have more than/i.test(msg),
+      );
+      expect(hasEnglish).to.be.true;
+    });
+  });
+
+  describe('unknown locale key', () => {
+    let app: AppWithServer;
+
+    before(async () => {
+      app = await createApp(
+        {
+          apiSpec,
+          formats: { 'starts-with-b': (v) => /^b/i.test(v) },
+          ajvLocale: 'xx-UNKNOWN',
+          validateRequests: { allErrors: true },
+        },
+        3011,
+        defineRoutes,
+        true,
+      );
+    });
+
+    after(() => app.server.close());
+
+    it('should not throw and should return English messages for an unknown locale', async () => {
+      const res = await request(app)
+        .post(`${app.basePath}/persons`)
+        .set('content-type', 'application/json')
+        .send({ bname: 'Maximillian' })
+        .expect(400);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      const hasEnglish = messages.some((msg) =>
+        /must NOT have more than/i.test(msg),
+      );
+      expect(hasEnglish).to.be.true;
+    });
+  });
+
+  describe('function locale returning undefined', () => {
+    let app: AppWithServer;
+
+    before(async () => {
+      app = await createApp(
+        {
+          apiSpec,
+          formats: { 'starts-with-b': (v) => /^b/i.test(v) },
+          ajvLocale: () => undefined,
+          validateRequests: { allErrors: true },
+        },
+        3012,
+        defineRoutes,
+        true,
+      );
+    });
+
+    after(() => app.server.close());
+
+    it('should not throw and should return English messages when locale function returns undefined', async () => {
+      const res = await request(app)
+        .post(`${app.basePath}/persons`)
+        .set('content-type', 'application/json')
+        .send({ bname: 'Maximillian' })
+        .expect(400);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      const hasEnglish = messages.some((msg) =>
+        /must NOT have more than/i.test(msg),
+      );
+      expect(hasEnglish).to.be.true;
+    });
+  });
+});

--- a/test/i18n.spec.ts
+++ b/test/i18n.spec.ts
@@ -120,6 +120,32 @@ describe('i18n – ajvLocale', () => {
         expect(msg).to.not.match(/must NOT have more than/i);
       });
     });
+
+    it('response errors should be in German when locale function returns "de"', async () => {
+      currentLocale = 'de';
+      const res = await request(app)
+        .get(`${app.basePath}/persons?bname=Maximillian`)
+        .expect(500);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      messages.forEach((msg) => {
+        expect(msg).to.not.match(/must NOT have more than/i);
+      });
+    });
+
+    it('response errors should be in Russian when locale function returns "ru"', async () => {
+      currentLocale = 'ru';
+      const res = await request(app)
+        .get(`${app.basePath}/persons?bname=Maximillian`)
+        .expect(500);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      messages.forEach((msg) => {
+        expect(msg).to.not.match(/must NOT have more than/i);
+      });
+    });
   });
 
   describe('no locale (default English)', () => {
@@ -131,6 +157,7 @@ describe('i18n – ajvLocale', () => {
           apiSpec,
           formats: { 'starts-with-b': (v) => /^b/i.test(v) },
           validateRequests: { allErrors: true },
+          validateResponses: { allErrors: true },
         },
         3010,
         defineRoutes,
@@ -155,6 +182,19 @@ describe('i18n – ajvLocale', () => {
       );
       expect(hasEnglish).to.be.true;
     });
+
+    it('response errors should be in English when no ajvLocale is set', async () => {
+      const res = await request(app)
+        .get(`${app.basePath}/persons?bname=Maximillian`)
+        .expect(500);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      const hasEnglish = messages.some((msg) =>
+        /must NOT have more than/i.test(msg),
+      );
+      expect(hasEnglish).to.be.true;
+    });
   });
 
   describe('unknown locale key', () => {
@@ -167,6 +207,7 @@ describe('i18n – ajvLocale', () => {
           formats: { 'starts-with-b': (v) => /^b/i.test(v) },
           ajvLocale: 'xx-UNKNOWN',
           validateRequests: { allErrors: true },
+          validateResponses: { allErrors: true },
         },
         3011,
         defineRoutes,
@@ -190,6 +231,19 @@ describe('i18n – ajvLocale', () => {
       );
       expect(hasEnglish).to.be.true;
     });
+
+    it('response errors should fall back to English for an unknown locale', async () => {
+      const res = await request(app)
+        .get(`${app.basePath}/persons?bname=Maximillian`)
+        .expect(500);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      const hasEnglish = messages.some((msg) =>
+        /must NOT have more than/i.test(msg),
+      );
+      expect(hasEnglish).to.be.true;
+    });
   });
 
   describe('function locale returning undefined', () => {
@@ -202,6 +256,7 @@ describe('i18n – ajvLocale', () => {
           formats: { 'starts-with-b': (v) => /^b/i.test(v) },
           ajvLocale: () => undefined,
           validateRequests: { allErrors: true },
+          validateResponses: { allErrors: true },
         },
         3012,
         defineRoutes,
@@ -217,6 +272,19 @@ describe('i18n – ajvLocale', () => {
         .set('content-type', 'application/json')
         .send({ bname: 'Maximillian' })
         .expect(400);
+
+      const messages: string[] = res.body.errors.map((e) => e.message);
+      expect(messages.length).to.be.greaterThan(0);
+      const hasEnglish = messages.some((msg) =>
+        /must NOT have more than/i.test(msg),
+      );
+      expect(hasEnglish).to.be.true;
+    });
+
+    it('response errors should fall back to English when locale function returns undefined', async () => {
+      const res = await request(app)
+        .get(`${app.basePath}/persons?bname=Maximillian`)
+        .expect(500);
 
       const messages: string[] = res.body.errors.map((e) => e.message);
       expect(messages.length).to.be.greaterThan(0);

--- a/typings/ajv-i18n.d.ts
+++ b/typings/ajv-i18n.d.ts
@@ -1,0 +1,5 @@
+declare module 'ajv-i18n' {
+  type LocalizeFunction = (errors: { message?: string }[] | null | undefined) => void;
+  const localize: Record<string, LocalizeFunction>;
+  export = localize;
+}


### PR DESCRIPTION
Localizes AJV validation error messages using [ajv-i18n](https://github.com/ajv-validator/ajv-i18n).

Closes #746
