### PR TITLE
feat: add before/after validation hooks for request and response bodies

### DIFF
--- a/src/framework/types.ts
+++ b/src/framework/types.ts
@@ -176,6 +176,8 @@ export interface OpenApiValidatorOpts {
   };
   operationHandlers?: false | string | OperationHandlerOptions;
   validateFormats?: boolean | 'fast' | 'full';
+  beforeRequestBodyValidation?: BeforeRequestBodyValidationHandlers;
+  afterResponseBodyValidation?: AfterResponseBodyValidationHandlers;
 }
 
 export interface NormalizedOpenApiValidatorOpts extends OpenApiValidatorOpts {
@@ -563,6 +565,25 @@ export interface OpenApiRequestMetadata {
 export interface OpenApiRequest extends Request {
   openapi?: OpenApiRequestMetadata;
 }
+
+export type BeforeRequestBodyValidationHandler = (
+  req: OpenApiRequest,
+  schema: OpenAPIV3.OperationObject,
+) => void | Promise<void>;
+
+export type BeforeRequestBodyValidationHandlers = {
+  [handlerName: string]: BeforeRequestBodyValidationHandler;
+};
+
+export type AfterResponseBodyValidationHandler = (
+  body: any,
+  req: OpenApiRequest,
+  schema: OpenAPIV3.OperationObject,
+) => any | Promise<any>;
+
+export type AfterResponseBodyValidationHandlers = {
+  [handlerName: string]: AfterResponseBodyValidationHandler;
+};
 
 export type OpenApiRequestHandler = (
   req: OpenApiRequest,

--- a/src/middlewares/openapi.response.validator.ts
+++ b/src/middlewares/openapi.response.validator.ts
@@ -14,6 +14,7 @@ import {
   OpenApiRequestMetadata,
   InternalServerError,
   ValidateResponseOpts,
+  AfterResponseBodyValidationHandlers,
 } from '../framework/types';
 import * as mediaTypeParser from 'media-typer';
 import * as contentTypeParser from 'content-type';
@@ -33,17 +34,20 @@ export class ResponseValidator {
   } = {};
   private eovOptions: ValidateResponseOpts;
   private serial: number;
+  private afterResponseBodyValidationHandlers?: AfterResponseBodyValidationHandlers;
 
   constructor(
     openApiSpec: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
     options: Options = {},
     eovOptions: ValidateResponseOpts = {},
     serial: number = -1,
+    afterResponseBodyValidationHandlers?: AfterResponseBodyValidationHandlers,
   ) {
     this.spec = openApiSpec;
     this.ajvBody = createResponseAjv(openApiSpec, options);
     this.eovOptions = eovOptions;
     this.serial = serial;
+    this.afterResponseBodyValidationHandlers = afterResponseBodyValidationHandlers;
 
     // This is a pseudo-middleware function. It doesn't get registered with
     // express via `use`
@@ -53,6 +57,67 @@ export class ResponseValidator {
   }
 
   public validate(): RequestHandler {
+    if (this.afterResponseBodyValidationHandlers) {
+      // Use async mung to support async after-response-body-validation hooks
+      const self = this;
+      return mung.jsonAsync(async (body, req, res) => {
+        if (req.openapi && self.serial == req.openapi.serial) {
+          const openapi = <OpenApiRequestMetadata>req.openapi;
+          // instead of openapi.schema, use openapi._responseSchema to get the response copy
+          const responses: OpenAPIV3.ResponsesObject = (<any>openapi)
+            ._responseSchema?.responses;
+
+          const validators = self._getOrBuildValidator(req, responses);
+          const path = req.originalUrl;
+          const statusCode = res.statusCode;
+          const contentType = res.getHeaders()['content-type'];
+          const accept = req.headers['accept'];
+          // if response has a content type use it, else use accept headers
+          const accepts: [string] = contentType
+            ? [contentType]
+            : accept
+            ? accept.split(',').map((h) => h.trim())
+            : [];
+
+          try {
+            self._validate({
+              validators,
+              body,
+              statusCode,
+              path,
+              accepts, // return 406 if not acceptable
+            });
+          } catch (err) {
+            // If a custom error handler was provided, we call that
+            if (err instanceof InternalServerError && self.eovOptions.onError) {
+              self.eovOptions.onError(err, body, req);
+              return body;
+            } else {
+              // No custom error handler, or something unexpected happened.
+              throw err;
+            }
+          }
+
+          // After successful validation, invoke the per-route after-response hook if configured
+          const handlerName: string =
+            openapi.schema['x-eov-after-response-body-validation'] as string;
+          if (handlerName) {
+            const handler = self.afterResponseBodyValidationHandlers[handlerName];
+            if (!handler) {
+              throw new InternalServerError({
+                path: path,
+                message: `afterResponseBodyValidation handler '${handlerName}' not found`,
+              });
+            }
+            const result = await handler(body, req, openapi.schema);
+            return result !== undefined ? result : body;
+          }
+        }
+        return body;
+      });
+    }
+
+    // Default synchronous path (no after-response-body-validation handlers configured)
     return mung.json((body, req, res) => {
       if (req.openapi && this.serial == req.openapi.serial) {
         const openapi = <OpenApiRequestMetadata>req.openapi;
@@ -65,7 +130,7 @@ export class ResponseValidator {
         const statusCode = res.statusCode;
         const contentType = res.getHeaders()['content-type'];
         const accept = req.headers['accept'];
-        // ir response has a content type use it, else use accept headers
+        // if response has a content type use it, else use accept headers
         const accepts: [string] = contentType
           ? [contentType]
           : accept

--- a/src/openapi.validator.ts
+++ b/src/openapi.validator.ts
@@ -15,6 +15,9 @@ import {
   OpenApiRequestMetadata,
   ValidateSecurityOpts,
   OpenAPIV3,
+  BeforeRequestBodyValidationHandlers,
+  AfterResponseBodyValidationHandlers,
+  InternalServerError,
 } from './framework/types';
 import { defaultResolver } from './resolvers';
 import { OperationHandlerOptions } from './framework/types';
@@ -189,6 +192,14 @@ export class OpenApiValidator {
       });
     }
 
+    // before request body validation hook middleware
+    if (this.options.beforeRequestBodyValidation) {
+      const beforeHookMw = this.beforeRequestBodyValidationMiddleware(
+        this.options.beforeRequestBodyValidation,
+      );
+      middlewares.push(beforeHookMw);
+    }
+
     // request middleware
     if (this.options.validateRequests) {
       let reqmw;
@@ -208,7 +219,11 @@ export class OpenApiValidator {
       middlewares.push(function responseMiddleware(req, res, next) {
         return pContext
           .then(({ responseApiDoc, context: { serial } }) => {
-            resmw = resmw || self.responseValidationMiddleware(responseApiDoc, serial);
+            resmw = resmw || self.responseValidationMiddleware(
+              responseApiDoc,
+              serial,
+              self.options.afterResponseBodyValidation,
+            );
             return resmw(req, res, next);
           })
           .catch(next);
@@ -291,13 +306,50 @@ export class OpenApiValidator {
     return (req, res, next) => requestValidator.validate(req, res, next);
   }
 
-  private responseValidationMiddleware(apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1, serial: number) {
+  private beforeRequestBodyValidationMiddleware(
+    handlers: BeforeRequestBodyValidationHandlers,
+  ): OpenApiRequestHandler {
+    return async function beforeRequestBodyValidationHook(req, res, next) {
+      try {
+        if (!req.openapi) {
+          // Route not matched by OpenAPI spec — skip
+          return next();
+        }
+        const handlerName: string =
+          req.openapi.schema['x-eov-before-request-body-validation'] as string;
+        if (!handlerName) {
+          // No hook configured for this operation
+          return next();
+        }
+        const handler = handlers[handlerName];
+        if (!handler) {
+          return next(
+            new InternalServerError({
+              path: (req as any).path,
+              message: `beforeRequestBodyValidation handler '${handlerName}' not found`,
+            }),
+          );
+        }
+        await handler(req, req.openapi.schema);
+        next();
+      } catch (err) {
+        next(err);
+      }
+    };
+  }
+
+  private responseValidationMiddleware(
+    apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1,
+    serial: number,
+    afterResponseBodyValidation?: AfterResponseBodyValidationHandlers,
+  ) {
     return new middlewares.ResponseValidator(
       apiDoc,
       this.ajvOpts.response,
       // This has already been converted from boolean if required
       this.options.validateResponses as ValidateResponseOpts,
-      serial
+      serial,
+      afterResponseBodyValidation,
     ).validate();
   }
 

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -1,0 +1,309 @@
+import * as path from 'path';
+import * as express from 'express';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { createApp } from './common/app';
+import { OpenApiValidatorOpts } from '../src/framework/types';
+import { AppWithServer } from './common/app.common';
+
+describe('hooks: beforeRequestBodyValidation and afterResponseBodyValidation', () => {
+  let app: AppWithServer;
+  let basePath: string;
+
+  // Flags to verify hooks are called
+  let beforeHookCalled = false;
+  let afterHookCalled = false;
+  let capturedSchema: any = null;
+
+  const eovConf: OpenApiValidatorOpts = {
+    apiSpec: path.join('test', 'resources', 'hooks.yaml'),
+    validateRequests: true,
+    validateResponses: true,
+    beforeRequestBodyValidation: {
+      transformRequest: async (req, schema) => {
+        beforeHookCalled = true;
+        capturedSchema = schema;
+        // Mutate req.body — the modified body gets validated
+        req.body.extra = 'added-by-hook';
+      },
+    },
+    afterResponseBodyValidation: {
+      transformResponse: async (body, req, schema) => {
+        afterHookCalled = true;
+        capturedSchema = schema;
+        if (Array.isArray(body)) {
+          return (body as any[]).map((item) => ({ ...item, transformed: true }));
+        }
+        return { ...(body as object), transformed: true };
+      },
+    },
+  };
+
+  before(async () => {
+    // useRoutes=false: no default common routes or error handler
+    app = await createApp(eovConf, 3020, undefined, false);
+    basePath = app.basePath;
+
+    app.use(
+      express
+        .Router()
+        .post(`${basePath}/hooks/echo`, (req, res) => {
+          res.json(req.body);
+        })
+        .get(`${basePath}/hooks/items`, (req, res) => {
+          res.json([
+            { id: 1, name: 'item1' },
+            { id: 2, name: 'item2' },
+          ]);
+        })
+        .post(`${basePath}/hooks/both`, (req, res) => {
+          res.json(req.body);
+        })
+        .get(`${basePath}/hooks/plain`, (req, res) => {
+          res.json({ message: 'hello' });
+        })
+        .post(`${basePath}/hooks/missing-handler`, (req, res) => {
+          res.json({ ok: true });
+        })
+        .get(`${basePath}/hooks/missing-after-handler`, (req, res) => {
+          res.json({ message: 'hello' });
+        }),
+    );
+
+    // Custom error handler
+    app.use((err, req, res, next) => {
+      res.status(err.status ?? 500).json({
+        message: err.message,
+        errors: err.errors,
+      });
+    });
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  beforeEach(() => {
+    beforeHookCalled = false;
+    afterHookCalled = false;
+    capturedSchema = null;
+  });
+
+  // ─── beforeRequestBodyValidation ───────────────────────────────────────────
+
+  it('before hook: is called for routes with x-eov-before-request-body-validation', async () => {
+    const res = await request(app)
+      .post(`${basePath}/hooks/echo`)
+      .set('Content-Type', 'application/json')
+      .send({ name: 'test', value: 42 });
+
+    expect(res.status).to.equal(200);
+    expect(beforeHookCalled).to.be.true;
+    expect(capturedSchema).to.have.property('operationId', 'echoPost');
+  });
+
+  it('before hook: can mutate req.body before validation runs', async () => {
+    // The hook adds `extra: "added-by-hook"` to req.body.
+    // The spec defines `extra` as an optional string on the request and response.
+    const res = await request(app)
+      .post(`${basePath}/hooks/echo`)
+      .set('Content-Type', 'application/json')
+      .send({ name: 'test', value: 42 });
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.have.property('extra', 'added-by-hook');
+  });
+
+  it('before hook: is NOT called for routes without x-eov extension', async () => {
+    const res = await request(app).get(`${basePath}/hooks/plain`);
+
+    expect(res.status).to.equal(200);
+    expect(beforeHookCalled).to.be.false;
+  });
+
+  it('before hook: errors thrown by the hook propagate to Express error handler', async () => {
+    const originalHandler = eovConf.beforeRequestBodyValidation!['transformRequest'];
+    eovConf.beforeRequestBodyValidation!['transformRequest'] = async () => {
+      throw new Error('hook threw an error');
+    };
+    try {
+      const res = await request(app)
+        .post(`${basePath}/hooks/echo`)
+        .set('Content-Type', 'application/json')
+        .send({ name: 'test', value: 42 });
+
+      expect(res.status).to.equal(500);
+      expect(res.body.message).to.equal('hook threw an error');
+    } finally {
+      eovConf.beforeRequestBodyValidation!['transformRequest'] = originalHandler;
+    }
+  });
+
+  it('before hook: spec references a handler name not in the map → 500 InternalServerError', async () => {
+    const res = await request(app)
+      .post(`${basePath}/hooks/missing-handler`)
+      .set('Content-Type', 'application/json')
+      .send({ name: 'test' });
+
+    expect(res.status).to.equal(500);
+    expect(res.body.message).to.include('nonExistentHandler');
+  });
+
+  // ─── afterResponseBodyValidation ───────────────────────────────────────────
+
+  it('after hook: is called for routes with x-eov-after-response-body-validation', async () => {
+    const res = await request(app).get(`${basePath}/hooks/items`);
+
+    expect(res.status).to.equal(200);
+    expect(afterHookCalled).to.be.true;
+    expect(capturedSchema).to.have.property('operationId', 'itemsGet');
+  });
+
+  it('after hook: can transform the response body before it is sent', async () => {
+    const res = await request(app).get(`${basePath}/hooks/items`);
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.be.an('array').with.length(2);
+    expect(res.body[0]).to.deep.include({ id: 1, name: 'item1', transformed: true });
+    expect(res.body[1]).to.deep.include({ id: 2, name: 'item2', transformed: true });
+  });
+
+  it('after hook: is NOT called for routes without x-eov extension', async () => {
+    const res = await request(app).get(`${basePath}/hooks/plain`);
+
+    expect(res.status).to.equal(200);
+    expect(afterHookCalled).to.be.false;
+  });
+
+  it('after hook: errors thrown by the hook propagate to Express error handler', async () => {
+    const originalHandler = eovConf.afterResponseBodyValidation!['transformResponse'];
+    eovConf.afterResponseBodyValidation!['transformResponse'] = async () => {
+      throw new Error('after hook threw an error');
+    };
+    try {
+      const res = await request(app).get(`${basePath}/hooks/items`);
+
+      expect(res.status).to.equal(500);
+    } finally {
+      eovConf.afterResponseBodyValidation!['transformResponse'] = originalHandler;
+    }
+  });
+
+  it('after hook: spec references a handler name not in the map → 500 InternalServerError', async () => {
+    const res = await request(app).get(`${basePath}/hooks/missing-after-handler`);
+
+    expect(res.status).to.equal(500);
+    expect(res.body.message).to.include('nonExistentAfterHandler');
+  });
+
+  // ─── Combined ───────────────────────────────────────────────────────────────
+
+  it('both hooks work together on routes that declare both extensions', async () => {
+    const res = await request(app)
+      .post(`${basePath}/hooks/both`)
+      .set('Content-Type', 'application/json')
+      .send({ name: 'test' });
+
+    expect(res.status).to.equal(200);
+    expect(beforeHookCalled).to.be.true;
+    expect(afterHookCalled).to.be.true;
+    // before hook added `extra`, after hook added `transformed`
+    expect(res.body).to.have.property('extra', 'added-by-hook');
+    expect(res.body).to.have.property('transformed', true);
+  });
+
+  it('async hooks (returning Promises) work correctly', async () => {
+    const originalHandler = eovConf.afterResponseBodyValidation!['transformResponse'];
+    eovConf.afterResponseBodyValidation!['transformResponse'] = async (body) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      if (Array.isArray(body)) {
+        return (body as any[]).map((item) => ({ ...item, asyncTransformed: true }));
+      }
+      return { ...(body as object), asyncTransformed: true };
+    };
+    try {
+      const res = await request(app).get(`${basePath}/hooks/items`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('array');
+      expect(res.body[0]).to.have.property('asyncTransformed', true);
+    } finally {
+      eovConf.afterResponseBodyValidation!['transformResponse'] = originalHandler;
+    }
+  });
+});
+
+describe('hooks: no regression when hooks are not configured', () => {
+  let app: AppWithServer;
+  let basePath: string;
+
+  const eovConf: OpenApiValidatorOpts = {
+    apiSpec: path.join('test', 'resources', 'hooks.yaml'),
+    validateRequests: true,
+    validateResponses: true,
+    // No beforeRequestBodyValidation or afterResponseBodyValidation
+  };
+
+  before(async () => {
+    app = await createApp(eovConf, 3021, undefined, false);
+    basePath = app.basePath;
+
+    app.use(
+      express
+        .Router()
+        .post(`${basePath}/hooks/echo`, (req, res) => {
+          res.json(req.body);
+        })
+        .get(`${basePath}/hooks/items`, (req, res) => {
+          res.json([{ id: 1, name: 'item1' }]);
+        })
+        .get(`${basePath}/hooks/plain`, (req, res) => {
+          res.json({ message: 'hello' });
+        }),
+    );
+
+    app.use((err, req, res, next) => {
+      res.status(err.status ?? 500).json({
+        message: err.message,
+        errors: err.errors,
+      });
+    });
+  });
+
+  after(() => {
+    app.server.close();
+  });
+
+  it('validates requests normally when no hooks are configured', async () => {
+    const res = await request(app)
+      .post(`${basePath}/hooks/echo`)
+      .set('Content-Type', 'application/json')
+      .send({ name: 'test', value: 42 });
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.equal({ name: 'test', value: 42 });
+  });
+
+  it('rejects invalid request body when no hooks are configured', async () => {
+    const res = await request(app)
+      .post(`${basePath}/hooks/echo`)
+      .set('Content-Type', 'application/json')
+      .send({ name: 'test' }); // missing required 'value'
+
+    expect(res.status).to.equal(400);
+  });
+
+  it('validates responses normally when no hooks are configured', async () => {
+    const res = await request(app).get(`${basePath}/hooks/items`);
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.equal([{ id: 1, name: 'item1' }]);
+  });
+
+  it('passes plain routes through without modification when no hooks are configured', async () => {
+    const res = await request(app).get(`${basePath}/hooks/plain`);
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.equal({ message: 'hello' });
+  });
+});

--- a/test/resources/hooks.yaml
+++ b/test/resources/hooks.yaml
@@ -1,0 +1,152 @@
+openapi: "3.0.2"
+info:
+  version: 1.0.0
+  title: Hooks Test
+  description: Test spec for beforeRequestBodyValidation and afterResponseBodyValidation hooks
+
+servers:
+  - url: /v1/
+
+paths:
+  /hooks/echo:
+    post:
+      x-eov-before-request-body-validation: transformRequest
+      operationId: echoPost
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - value
+              properties:
+                name:
+                  type: string
+                value:
+                  type: number
+                extra:
+                  type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - name
+                  - value
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: number
+                  extra:
+                    type: string
+
+  /hooks/items:
+    get:
+      x-eov-after-response-body-validation: transformResponse
+      operationId: itemsGet
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+
+  /hooks/both:
+    post:
+      x-eov-before-request-body-validation: transformRequest
+      x-eov-after-response-body-validation: transformResponse
+      operationId: bothPost
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                extra:
+                  type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - name
+                properties:
+                  name:
+                    type: string
+                  extra:
+                    type: string
+                  transformed:
+                    type: boolean
+
+  /hooks/plain:
+    get:
+      operationId: plainGet
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+
+  /hooks/missing-handler:
+    post:
+      x-eov-before-request-body-validation: nonExistentHandler
+      operationId: missingHandlerPost
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: OK
+
+  /hooks/missing-after-handler:
+    get:
+      x-eov-after-response-body-validation: nonExistentAfterHandler
+      operationId: missingAfterHandlerGet
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string


### PR DESCRIPTION
Introduce two new extension points in `OpenApiValidatorOpts`:

- `beforeRequestBodyValidation`: handlers keyed by name, invoked (via `x-eov-before-request-body-validation` on an operation) before the request body is validated, allowing mutations or enrichment of `req.body` and access to the operation schema.
- `afterResponseBodyValidation`: handlers keyed by name, invoked (via `x-eov-after-response-body-validation` on an operation) after the response body passes validation, allowing transformation of the outgoing body before it is sent.

Both handler types support async execution. The response hook uses `mung.jsonAsync` when handlers are registered. Corresponding types (`BeforeRequestBodyValidationHandler/Handlers` and `AfterResponseBodyValidationHandler/Handlers`) are exported from `framework/types`.

Full integration tests are added covering: hook invocation, body mutation, schema capture, skipping routes without the extension field, async handlers, and error handling for missing or failing hooks.