### PR TITLE
Handle OpenAPI 3.1 array type specifier in SerDes

### DIFF
--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -256,7 +256,7 @@ export class SchemaPreprocessor {
         Array.isArray(schema.type) && schema.type.includes('array'))
       ) && schema.items) {
         // `type` may be an array of options in OpenAPI 3.1
-        // (e.g. ['array', 'null']),
+        // (e.g. ['array', 'null'])
         const child = new Node(node, schema.items, [...node.path, 'items']);
         recurse(node, child, opts);
       } else if (schema.properties) {
@@ -460,7 +460,7 @@ export class SchemaPreprocessor {
     state: TraversalState,
   ) {
     // `type` may be a string (`'string'`) or, in OpenAPI 3.1, an array of
-    // options (e.g. `['string', 'null']`). A serdes format is a string format,
+    // options (e.g. `['string', 'null']`)
     const types = Array.isArray(schema.type) ? schema.type : [schema.type];
     const isSerDesString =
       types.includes('string') &&
@@ -476,7 +476,7 @@ export class SchemaPreprocessor {
         // Ajv requires `type` keyword with `nullable` (regardless of value).
         (<any>schema).type = ['string', 'number', 'boolean', 'object', 'array'];
       } else if (types.includes('null')) {
-        // Normalize the OpenAPI 3.1 `['string', 'null']` form to `nullable` so
+        // Normalize the OpenAPI 3.1 `['string', 'null']` form to `nullable`.
         (<any>schema).nullable = true;
         (<any>schema).type = ['string', 'number', 'boolean', 'object', 'array'];
       } else {

--- a/src/middlewares/parsers/schema.preprocessor.ts
+++ b/src/middlewares/parsers/schema.preprocessor.ts
@@ -252,7 +252,11 @@ export class SchemaPreprocessor {
           const child = new Node(node, s, [...node.path, 'anyOf', i + '']);
           recurse(node, child, opts);
         });
-      } else if (schema.type === 'array' && schema.items) {
+      } else if ((schema.type === 'array' || (
+        Array.isArray(schema.type) && schema.type.includes('array'))
+      ) && schema.items) {
+        // `type` may be an array of options in OpenAPI 3.1
+        // (e.g. ['array', 'null']),
         const child = new Node(node, schema.items, [...node.path, 'items']);
         recurse(node, child, opts);
       } else if (schema.properties) {
@@ -455,15 +459,25 @@ export class SchemaPreprocessor {
     schema: SchemaObject,
     state: TraversalState,
   ) {
+    // `type` may be a string (`'string'`) or, in OpenAPI 3.1, an array of
+    // options (e.g. `['string', 'null']`). A serdes format is a string format,
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const isSerDesString =
+      types.includes('string') &&
+      types.every((t) => t === 'string' || t === 'null');
     if (
-      schema.type === 'string' &&
+      isSerDesString &&
       !!schema.format &&
       this.serDesMap[schema.format]
     ) {
       const serDes = this.serDesMap[schema.format];
-      (<any>schema)['x-eov-type'] = schema.type;
+      (<any>schema)['x-eov-type'] = 'string';
       if ('nullable' in schema) {
         // Ajv requires `type` keyword with `nullable` (regardless of value).
+        (<any>schema).type = ['string', 'number', 'boolean', 'object', 'array'];
+      } else if (types.includes('null')) {
+        // Normalize the OpenAPI 3.1 `['string', 'null']` form to `nullable` so
+        (<any>schema).nullable = true;
         (<any>schema).type = ['string', 'number', 'boolean', 'object', 'array'];
       } else {
         delete schema.type;

--- a/test/openapi_3.1/resources/serdes_nullable_array_items.yaml
+++ b/test/openapi_3.1/resources/serdes_nullable_array_items.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: Serdes with OpenAPI 3.1 array type specifier
+  version: 1.0.0
+servers:
+  - url: /v1
+paths:
+  /nullable_dates:
+    get:
+      responses:
+        200:
+          description: 'Get nullable array of nullable dates'
+          content:
+            application/json:
+              schema:
+                # 3.1 syntax nullable array
+                type: [array, 'null']
+                items:
+                  type: object
+                  properties:
+                    createdAt:
+                      # 3.1 syntax nullable item
+                      type: [string, 'null']
+                      format: date-time

--- a/test/openapi_3.1/serdes_nullable_array_items.ts
+++ b/test/openapi_3.1/serdes_nullable_array_items.ts
@@ -1,0 +1,50 @@
+import * as path from 'path';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { createApp } from '../common/app';
+
+import { date, dateTime } from '../../src/framework/base.serdes';
+import { AppWithServer } from '../common/app.common';
+
+
+describe('Serdes with OpenAPI 3.1 array type specifier', () => {
+  let app: AppWithServer;
+  const isoDate = '2026-04-06T23:07:24.515Z';
+  const apiSpecPath = path.join(
+    'test',
+    'openapi_3.1',
+    'resources',
+    'serdes_nullable_array_items.yaml'
+  );
+
+  before(async () => {
+    app = await createApp(
+      {
+        apiSpec: apiSpecPath,
+        validateRequests: true,
+        validateResponses: true,
+        serDes: [date, dateTime],
+      },
+      3005,
+      (app) => {
+        app.get([`${app.basePath}/nullable_dates`], (req, res) => {
+          res.json([{ createdAt: null }, { createdAt: new Date(isoDate) }]);
+        });
+      },
+      false,
+    );
+    return app;
+  });
+
+  after(() => {
+    app.server.close();
+  });
+  it('should serialize an unserialized Date and allow null for a nullable date-time item', async () =>
+    request(app)
+      .get(`${app.basePath}/nullable_dates`)
+      .expect(200)
+      .then((r) => {
+        expect(r.body[1].createdAt).to.equal(isoDate);
+        expect(r.body[0].createdAt).to.equal(null);
+      }));
+});


### PR DESCRIPTION
Handle OpenAPI 3.1 array type specifier in SerDes.
Add test.

**Example type specifiers:** `[string, 'null']`, `[array, 'null']`

**Example schema:**
```
paths:
  /nullable_dates:
    get:
      responses:
        200:
          description: 'Get nullable array of nullable dates'
          content:
            application/json:
              schema:
                # 3.1 syntax nullable array
                type: [array, 'null']
                items:
                  type: object
                  properties:
                    createdAt:
                      # 3.1 syntax nullable item
                      type: [string, 'null']
                      format: date-time
```

Running validator on response according to this schema would previously throw this warning:
`/response/1/createdAt must be string,null`

**Related issue:** https://github.com/cdimascio/express-openapi-validator/issues/1177