### PR TITLE
perf: cache route matchers

### DIFF
--- a/src/framework/openapi.context.ts
+++ b/src/framework/openapi.context.ts
@@ -1,3 +1,4 @@
+import { pathToRegexp } from 'path-to-regexp';
 import { OpenAPIV3 } from './types';
 import { Spec, RouteMetadata } from './openapi.spec.loader';
 
@@ -5,6 +6,12 @@ export interface RoutePair {
   expressRoute: string;
   openApiRoute: string;
 }
+
+interface RouteMatcher {
+  regexp: RegExp;
+  paramKeys: string[];
+}
+
 export class OpenApiContext {
   public readonly apiDoc: OpenAPIV3.DocumentV3 | OpenAPIV3.DocumentV3_1;
   public readonly expressRouteMap = {};
@@ -15,6 +22,7 @@ export class OpenApiContext {
   public readonly serial: number;
   private readonly basePaths: string[];
   private readonly ignorePaths: RegExp | Function;
+  private readonly routeMatcherCache = new Map<string, RouteMatcher>();
 
   constructor(
     spec: Spec,
@@ -54,6 +62,28 @@ export class OpenApiContext {
       };
     }
     return null;
+  }
+
+  public getRouteMatcher(
+    expressRoute: string,
+    strict: boolean,
+    sensitive: boolean,
+  ): RouteMatcher {
+    const cacheKey = JSON.stringify([expressRoute, strict, sensitive]);
+    let matcher = this.routeMatcherCache.get(cacheKey);
+    if (!matcher) {
+      const pathOpts = {
+        sensitive,
+        strict,
+      };
+      const regexpObj = pathToRegexp(expressRoute, pathOpts);
+      matcher = {
+        regexp: regexpObj.regexp,
+        paramKeys: regexpObj.keys.map((k) => `${k.name}`),
+      };
+      this.routeMatcherCache.set(cacheKey, matcher);
+    }
+    return matcher;
   }
 
   private methods(route: string) {

--- a/src/middlewares/openapi.metadata.ts
+++ b/src/middlewares/openapi.metadata.ts
@@ -1,5 +1,4 @@
 import { zipObject } from './util';
-import { pathToRegexp } from 'path-to-regexp';
 import { Response, NextFunction } from 'express';
 import { OpenApiContext } from '../framework/openapi.context';
 import {
@@ -82,17 +81,16 @@ export function applyOpenApiMetadata(
       const _schema = responseApiDoc?.paths[pathKey][method.toLowerCase()];
       const strict = !!req.app.enabled('strict routing');
       const sensitive = !!req.app.enabled('case sensitive routing');
-      const pathOpts = {
-        sensitive,
+      const matcher = openApiContext.getRouteMatcher(
+        expressRoute,
         strict,
-      };
-      const regexpObj = pathToRegexp(expressRoute, pathOpts);
-      const matchedRoute = regexpObj.regexp.exec(path);
+        sensitive,
+      );
+      const matchedRoute = matcher.regexp.exec(path);
       if (matchedRoute) {
-        const paramKeys = regexpObj.keys.map((k) => k.name);
         try {
           const paramsVals = matchedRoute.slice(1).map(decodeURIComponent);
-          const pathParams = zipObject(paramKeys, paramsVals);
+          const pathParams = zipObject(matcher.paramKeys, paramsVals);
 
           const r = {
             schema,

--- a/test/route.matcher.spec.ts
+++ b/test/route.matcher.spec.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import { OpenApiContext } from '../src/framework/openapi.context';
+import { Spec } from '../src/framework/openapi.spec.loader';
+
+describe('route matcher cache', () => {
+  it('reuses compiled route matchers for the same route and options', () => {
+    const context = makeContext();
+
+    const first = context.getRouteMatcher('/pets/:petId', false, false);
+    const second = context.getRouteMatcher('/pets/:petId', false, false);
+
+    expect(second).to.equal(first);
+    expect(first.regexp.exec('/pets/123')).to.not.equal(null);
+    expect(first.paramKeys).to.deep.equal(['petId']);
+  });
+
+  it('caches separate matchers for strict and case-sensitive routing options', () => {
+    const context = makeContext();
+
+    const defaultMatcher = context.getRouteMatcher('/pets/:petId', false, false);
+    const strictMatcher = context.getRouteMatcher('/pets/:petId', true, false);
+    const sensitiveMatcher = context.getRouteMatcher('/pets/:petId', false, true);
+
+    expect(strictMatcher).to.not.equal(defaultMatcher);
+    expect(sensitiveMatcher).to.not.equal(defaultMatcher);
+    expect(context.getRouteMatcher('/pets/:petId', true, false)).to.equal(strictMatcher);
+    expect(context.getRouteMatcher('/pets/:petId', false, true)).to.equal(sensitiveMatcher);
+  });
+});
+
+function makeContext(): OpenApiContext {
+  const spec: Spec = {
+    apiDoc: {
+      openapi: '3.0.0',
+      info: {
+        title: 'test',
+        version: '1.0.0',
+      },
+      paths: {
+        '/pets/{petId}': {
+          get: {
+            responses: {
+              200: {
+                description: 'ok',
+              },
+            },
+          },
+        },
+      },
+    },
+    basePaths: [''],
+    routes: [
+      {
+        basePath: '',
+        expressRoute: '/pets/:petId',
+        openApiRoute: '/pets/{petId}',
+        method: 'GET',
+        pathParams: ['petId'],
+      },
+    ],
+    serial: 1,
+  };
+
+  return new OpenApiContext(spec, undefined, false, false);
+}


### PR DESCRIPTION
## Summary

Cache compiled `path-to-regexp` route matchers on each `OpenApiContext`.

Route lookup previously compiled every scanned route on every request. This
change reuses the compiled regular expression and parameter keys for subsequent
requests while preserving the existing ordered route scan and matching
behavior.

Cache entries are scoped to an `OpenApiContext` and keyed by:

- Express route
- strict routing setting
- case-sensitive routing setting

## Benchmark

I ran a targeted synthetic benchmark of the route-matching loop before and
after caching. Each request matched the final registered route, and each
scenario performed 100,000 route comparisons per round.

- Node.js: v24.12.0
- CPU: AMD Ryzen 7 3800X
- Seven rounds, median reported
- Cache warmed before measurement

| Registered routes | Lookups | Uncached | Cached | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 10 | 10,000 | 262.05 ms | 25.02 ms | 10.5x |
| 100 | 1,000 | 274.24 ms | 24.50 ms | 11.2x |
| 1,000 | 100 | 278.80 ms | 28.95 ms | 9.6x |

These numbers isolate route matching rather than measuring end-to-end request
throughput. This PR removes repeated matcher compilation; route selection
remains an ordered O(N) scan.

<details>
<summary>Benchmark script</summary>

Save as `benchmark.js` in the repository root and run:

```sh
node --expose-gc benchmark.js
```

```js
const { performance } = require('node:perf_hooks');
const { pathToRegexp } = require('path-to-regexp');

const scenarios = [
  { routeCount: 10, lookups: 10_000 },
  { routeCount: 100, lookups: 1_000 },
  { routeCount: 1_000, lookups: 100 },
];
const rounds = 7;

function median(values) {
  const sorted = [...values].sort((a, b) => a - b);
  return sorted[Math.floor(sorted.length / 2)];
}

function makeUncachedLookup(routes) {
  return (path) => {
    for (const route of routes) {
      const matcher = pathToRegexp(route, {
        sensitive: false,
        strict: false,
      });
      const match = matcher.regexp.exec(path);
      if (match) return matcher.keys.length + match.length;
    }
    return 0;
  };
}

function makeCachedLookup(routes) {
  const cache = new Map();

  return (path) => {
    for (const route of routes) {
      const cacheKey = JSON.stringify([route, false, false]);
      let matcher = cache.get(cacheKey);
      if (!matcher) {
        const compiled = pathToRegexp(route, {
          sensitive: false,
          strict: false,
        });
        matcher = {
          regexp: compiled.regexp,
          paramKeys: compiled.keys.map((key) => key.name),
        };
        cache.set(cacheKey, matcher);
      }
      const match = matcher.regexp.exec(path);
      if (match) return matcher.paramKeys.length + match.length;
    }
    return 0;
  };
}

function measure(fn, path, lookups) {
  let checksum = 0;
  const started = performance.now();
  for (let i = 0; i < lookups; i += 1) {
    checksum += fn(path);
  }
  return {
    elapsed: performance.now() - started,
    checksum,
  };
}

console.log(`Node ${process.version}`);
console.log(`Rounds: ${rounds}; median reported; target is the last route`);
console.log('');
console.log('routes\tlookups\tuncached ms\tcached ms\tspeedup');

for (const { routeCount, lookups } of scenarios) {
  const routes = Array.from(
    { length: routeCount },
    (_, index) => `/resource/${index}/:id`,
  );
  const path = `/resource/${routeCount - 1}/123`;
  const uncachedLookup = makeUncachedLookup(routes);
  const cachedLookup = makeCachedLookup(routes);

  cachedLookup(path);
  uncachedLookup(path);

  const uncachedTimes = [];
  const cachedTimes = [];

  for (let round = 0; round < rounds; round += 1) {
    if (global.gc) global.gc();
    const first =
      round % 2 === 0
        ? measure(uncachedLookup, path, lookups)
        : measure(cachedLookup, path, lookups);
    if (global.gc) global.gc();
    const second =
      round % 2 === 0
        ? measure(cachedLookup, path, lookups)
        : measure(uncachedLookup, path, lookups);

    const uncached = round % 2 === 0 ? first : second;
    const cached = round % 2 === 0 ? second : first;
    if (uncached.checksum !== cached.checksum) {
      throw new Error('Benchmark implementations returned different results');
    }
    uncachedTimes.push(uncached.elapsed);
    cachedTimes.push(cached.elapsed);
  }

  const uncachedMedian = median(uncachedTimes);
  const cachedMedian = median(cachedTimes);
  console.log(
    [
      routeCount,
      lookups,
      uncachedMedian.toFixed(2),
      cachedMedian.toFixed(2),
      `${(uncachedMedian / cachedMedian).toFixed(1)}x`,
    ].join('\t'),
  );
}
```

</details>

## Verification

- `npm run compile`
- `npm test` (472 passing, 32 pending)
- `npm run test:all` (Express 4 and latest)
